### PR TITLE
fix incorrect icon on Wayland

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "github-desktop",
+  "desktopName": "github-desktop-plus",
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->


## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

The filename of desktop file shipped with AUR package `github-desktop-plus-bin` is `github-desktop-plus.desktop` while the application itself expects the filename to be `GitHub Desktop.desktop`.

The mismatch filename will result in wrong icon when running on Wayland. This patch is to correct the filename of desktop file.

For more details see https://github.com/shiftkey/desktop/issues/1176 and https://github.com/shiftkey/desktop/pull/1226
