### PR TITLE
add StartupWMClass to .desktop file

### DIFF
--- a/publish/aur/github-desktop-plus.desktop
+++ b/publish/aur/github-desktop-plus.desktop
@@ -9,3 +9,4 @@ Type=Application
 Icon=github-desktop-plus
 Categories=Development;
 MimeType=x-scheme-handler/x-github-client;x-scheme-handler/x-github-desktop-auth;x-scheme-handler/x-github-desktop-dev-auth;
+StartupWMClass=GitHub Desktop


### PR DESCRIPTION
This is needed so KDE Plasma (maybe also other DE) knows that the new process belongs to the .desktop file. By default the "Name" seems to be used. So either this can be done or somewhere in the source code the process name is renamed

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
