### PR TITLE
fix broken symlink for cli tool

### DIFF
--- a/publish/aur/PKGBUILD-bin.sh
+++ b/publish/aur/PKGBUILD-bin.sh
@@ -58,5 +58,5 @@ package() {
     install -Dm755 "$srcdir/launch-app.sh" "$pkgdir/usr/bin/${_pkgname}"
 
     chmod +x "$INSTALL_DIR/resources/app/static/github"
-    ln -s "$INSTALL_DIR/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
+    ln -s "/opt/${_pkgname}/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
 }

--- a/publish/aur/PKGBUILD-git.sh
+++ b/publish/aur/PKGBUILD-git.sh
@@ -89,7 +89,7 @@ package() {
     install -Dm755 "$srcdir/launch-app.sh" "$pkgdir/usr/bin/${_pkgname}"
 
     chmod +x "$INSTALL_DIR/resources/app/static/github"
-    ln -s "$INSTALL_DIR/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
+    ln -s "/opt/${_pkgname}/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
 
     install -Dm0644 "$srcdir/${_pkgname}.desktop" "$pkgdir/usr/share/applications/${_pkgname}.desktop"
 }

--- a/publish/aur/PKGBUILD.sh
+++ b/publish/aur/PKGBUILD.sh
@@ -83,7 +83,7 @@ package() {
     install -Dm755 "$srcdir/launch-app.sh" "$pkgdir/usr/bin/$pkgname"
 
     chmod +x "$INSTALL_DIR/resources/app/static/github"
-    ln -s "$INSTALL_DIR/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
+    ln -s "/opt/$pkgname/resources/app/static/github" "$pkgdir/usr/bin/github-desktop-plus-cli"
 
     install -Dm0644 "$srcdir/$pkgname.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- The symlink of cli tool on Arch Linux is broken

