### PR TITLE
Fix IME composition handling in branch name input

### DIFF
--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -421,8 +421,6 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
       this.setState({ value, valueCleared: false })
     }
 
-    if (this.props.onValueChanged !== undefined) {
-      this.props.onValueChanged(value)
-    }
+    this.props.onValueChanged?.(value)
   }
 }


### PR DESCRIPTION
Emit value changes on IME composition end so branch name updates correctly. Enable Create button for non-Latin input during branch creation.

Verified: typing Chinese in the Create Branch dialog now enables the Create button.

The previous fix didn’t catch this because my project branch name started with a number, which still triggered the update, so the issue didn’t surface in my testing. This change should fully resolve the problem now.