### PR TITLE
Rename binaries before generating .zsync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,24 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_CODE_SIGNING_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_SECRET }}
+
+      # GitHubDesktop-linux-<arch>-<old_version>.<ext> -> GitHubDesktopPlus-<release_tag>-linux-<arch>.<ext>
+      - name: Rename Linux artifacts
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/ ]]; then
+            RELEASE_TAG=${GITHUB_REF/refs\/tags\//}
+          else
+            RELEASE_TAG="v0.0.0"
+          fi
+
+          for file in $(find ./artifacts -type f -name "GitHubDesktop-linux-*"); do
+            new_name=$(echo "$file" | sed -E "s/GitHubDesktop-linux-(.*)-[0-9]+\\.[0-9]+\\.[0-9]+(-beta[0-9]+)?\\.(.*)/GitHubDesktopPlus-${RELEASE_TAG}-linux-\\1.\\3/")
+            new_name=$(echo $new_name | sed -E "s/linux-amd64/linux-x86_64/")
+            new_name=$(echo $new_name | sed -E "s/linux-aarch64/linux-arm64/")
+            mv --verbose "$file" "$new_name"
+          done
+
       - name: Generate AppImage zsync
         if: ${{ runner.os == 'Linux' }}
         run:
@@ -221,19 +239,10 @@ jobs:
           # Export for downstream jobs
           echo "${VERSION_WITHOUT_V}" > VERSION_WITHOUT_V.txt
 
-      # GitHubDesktop-linux-<arch>-<old_version>.<ext> -> GitHubDesktopPlus-<release_tag>-linux-<arch>.<ext>
-      # GitHubDesktop-linux-<arch>-<old_version>-beta1.<ext> -> GitHubDesktopPlus-<release_tag>-linux-<arch>.<ext>
       # GitHubDesktopSetup-<arch>.<ext> -> GitHubDesktopPlus-<release_tag>-windows-<arch>.<ext>
       # GitHub Desktop Plus-<arch>.zip -> GitHubDesktopPlus-<release_tag>-macOS-<arch>.zip
-      - name: Rename artifacts
+      - name: Rename Windows/macOS artifacts
         run: |
-          for file in $(find ./artifacts -type f -name "GitHubDesktop-linux-*"); do
-            new_name=$(echo "$file" | sed -E "s/GitHubDesktop-linux-(.*)-[0-9]+\\.[0-9]+\\.[0-9]+(-beta[0-9]+)?\\.(.*)/GitHubDesktopPlus-${{ env.RELEASE_TAG }}-linux-\\1.\\3/")
-            new_name=$(echo $new_name | sed -E "s/linux-amd64/linux-x86_64/")
-            new_name=$(echo $new_name | sed -E "s/linux-aarch64/linux-arm64/")
-            mv --verbose "$file" "$new_name"
-          done
-
           for file in $(find ./artifacts -type f -name "GitHubDesktopSetup-*"); do
             new_name=$(echo "$file" | sed -E "s/GitHubDesktopSetup-(.*)\\.(.*)/GitHubDesktopPlus-${{ env.RELEASE_TAG }}-windows-\\1.\\2/")
             mv --verbose "$file" "$new_name"
@@ -295,15 +304,6 @@ jobs:
       - name: Set VERSION_WITHOUT_V env var
         run: |
           echo "VERSION_WITHOUT_V=$(cat ./VERSION_WITHOUT_V.txt)" >> $GITHUB_ENV
-
-      - name: Rename artifacts
-        run: |
-          for file in $(find ./artifacts -type f -name "GitHubDesktop-linux-*"); do
-            new_name=$(echo "$file" | sed -E "s/GitHubDesktop-linux-(.*)-[0-9]+\\.[0-9]+\\.[0-9]+(-beta[0-9]+)?\\.(.*)/GitHubDesktopPlus-v${{ env.VERSION_WITHOUT_V }}-linux-\\1.\\3/")
-            new_name=$(echo $new_name | sed -E "s/linux-amd64/linux-x86_64/")
-            new_name=$(echo $new_name | sed -E "s/linux-aarch64/linux-arm64/")
-            mv --verbose "$file" "$new_name"
-          done
 
       - name: Prepare PKGBUILD files
         run: |


### PR DESCRIPTION
Rename the Linux binaries _before_ the `.zsync` file is generated. See #53.