### PR TITLE
Auto-enable worktrees setting from Show Worktrees List menu

### DIFF
--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -17,6 +17,7 @@ export enum BannerType {
   SuccessfulReorder = 'SuccessfulReorder',
   ConflictsFound = 'ConflictsFound',
   OSVersionNoLongerSupported = 'OSVersionNoLongerSupported',
+  WorktreesEnabled = 'WorktreesEnabled',
 }
 
 export type Banner =
@@ -122,3 +123,4 @@ export type Banner =
       readonly onOpenConflictsDialog: () => void
     }
   | { readonly type: BannerType.OSVersionNoLongerSupported }
+  | { readonly type: BannerType.WorktreesEnabled }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -968,6 +968,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (!this.state.showWorktrees) {
       this.props.dispatcher.setShowWorktrees(true)
+      this.setBanner({ type: BannerType.WorktreesEnabled })
     }
 
     if (

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { assertNever } from '../../lib/fatal-error'
 
 import { Banner, BannerType } from '../../models/banner'
+import { PopupType } from '../../models/popup'
+import { PreferencesTab } from '../../models/preferences'
 
 import { Dispatcher } from '../dispatcher'
 import { MergeConflictsBanner } from './merge-conflicts-banner'
@@ -19,6 +21,7 @@ import { SuccessfulSquash } from './successful-squash'
 import { SuccessBanner } from './success-banner'
 import { ConflictsFoundBanner } from './conflicts-found-banner'
 import { OSVersionNoLongerSupportedBanner } from './os-version-no-longer-supported-banner'
+import { LinkButton } from '../lib/link-button'
 
 export function renderBanner(
   banner: Banner,
@@ -171,6 +174,31 @@ export function renderBanner(
       )
     case BannerType.OSVersionNoLongerSupported:
       return <OSVersionNoLongerSupportedBanner onDismissed={onDismissed} />
+    case BannerType.WorktreesEnabled: {
+      const label = __DARWIN__
+        ? 'Appearance Settings'
+        : 'Appearance Options'
+      return (
+        <SuccessBanner
+          key="worktrees-enabled"
+          timeout={8000}
+          onDismissed={onDismissed}
+        >
+          Worktrees enabled. You can change this in{' '}
+          <LinkButton
+            onClick={() =>
+              dispatcher.showPopup({
+                type: PopupType.Preferences,
+                initialSelectedTab: PreferencesTab.Appearance,
+              })
+            }
+          >
+            {label}
+          </LinkButton>
+          .
+        </SuccessBanner>
+      )
+    }
     default:
       return assertNever(banner, `Unknown popup type: ${banner}`)
   }


### PR DESCRIPTION
## Description

This addresses the discoverability issue raised in https://github.com/pol-rivero/github-desktop-plus/pull/62#issuecomment-3954471775.

When a user clicks **View → Show Worktrees List** (Cmd+E) and the worktrees setting is off (the default), the app now automatically enables the setting and opens the worktree foldout immediately — no trip to Preferences required.

A success banner ("Worktrees panel enabled. You can change this in **Preferences**.") is shown to inform the user that the setting was turned on. It auto-dismisses after 8 seconds.

### Screenshots

<img width="1220" height="772" alt="Screenshot 2026-02-25 at 9 57 06 AM" src="https://github.com/user-attachments/assets/20e6b415-3784-4dc8-a924-cd5f20d0e6e4" />


## Release notes

Notes: Auto-enable worktrees panel when using the Show Worktrees List menu item.