### PR TITLE
Update name of generated binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 /app/test/fixtures/** -text
-/app/static/win32/github.sh eol=lf
+/app/static/win32/github-desktop-plus-cli.sh eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,17 +189,6 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_SECRET }}
 
-      # GitHubDesktop-linux-<arch>-<old_version>.<ext> -> GitHubDesktopPlus-<release_tag>-linux-<arch>.<ext>
-      - name: Rename Linux artifacts
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          for file in $(find ./dist -type f -name "GitHubDesktop-linux-*"); do
-            new_name=$(echo "$file" | sed -E "s/GitHubDesktop-linux-(.*)-([0-9]+\\.)+[0-9]+(-beta[0-9]+)?\\.(.*)/GitHubDesktopPlus-v${APP_VERSION}-linux-\\1.\\4/")
-            new_name=$(echo $new_name | sed -E "s/linux-amd64/linux-x86_64/")
-            new_name=$(echo $new_name | sed -E "s/linux-aarch64/linux-arm64/")
-            mv --verbose "$file" "$new_name"
-          done
-
       - name: Generate AppImage zsync
         if: ${{ runner.os == 'Linux' }}
         run:
@@ -209,10 +198,10 @@ jobs:
         with:
           name: ${{matrix.friendlyName}}-${{matrix.arch}}
           path: |
-            dist/GitHub Desktop Plus-${{matrix.arch}}.zip
-            dist/GitHubDesktop-*.nupkg
-            dist/GitHubDesktopSetup-${{matrix.arch}}.exe
-            dist/GitHubDesktopSetup-${{matrix.arch}}.msi
+            dist/*-macOS-*.zip
+            dist/*.exe
+            dist/*.msi
+            dist/*.nupkg
             dist/*.AppImage
             dist/*.AppImage.zsync
             dist/*.deb
@@ -241,20 +230,6 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: './artifacts'
-
-      # GitHubDesktopSetup-<arch>.<ext> -> GitHubDesktopPlus-<release_tag>-windows-<arch>.<ext>
-      # GitHub Desktop Plus-<arch>.zip -> GitHubDesktopPlus-<release_tag>-macOS-<arch>.zip
-      - name: Rename Windows/macOS artifacts
-        run: |
-          for file in $(find ./artifacts -type f -name "GitHubDesktopSetup-*"); do
-            new_name=$(echo "$file" | sed -E "s/GitHubDesktopSetup-(.*)\\.(.*)/GitHubDesktopPlus-v${APP_VERSION}-windows-\\1.\\2/")
-            mv --verbose "$file" "$new_name"
-          done
-
-          find ./artifacts -type f -name "GitHub Desktop Plus-*.zip" -print0 | while IFS= read -r -d '' file; do
-            new_name=$(echo "$file" | sed -E "s/GitHub Desktop Plus-(.*)\\.zip/GitHubDesktopPlus-v${APP_VERSION}-macOS-\\1.zip/")
-            mv --verbose "$file" "$new_name"
-          done
 
       - name: Read release notes
         id: release_notes

--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -18,7 +18,7 @@ const run = (...args: Array<string>) => {
   if (process.platform === 'darwin') {
     execFile('open', ['-n', join(__dirname, '../../..'), '--args', ...args], cb)
   } else if (process.platform === 'win32') {
-    const exeName = `GitHubDesktop${__DEV__ ? '-dev' : ''}.exe`
+    const exeName = `GitHubDesktopPlus${__DEV__ ? '-dev' : ''}.exe`
     spawn(join(__dirname, `../../${exeName}`), args, {
       detached: true,
       stdio: 'ignore',

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -99,11 +99,11 @@ function resolveVersionedPath(binPath: string, relativePath: string): string {
 function writeBatchScriptCLITrampoline(binPath: string): Promise<void> {
   const versionedPath = resolveVersionedPath(
     binPath,
-    'resources/app/static/github.bat'
+    'resources/app/static/github-desktop-plus-cli.bat'
   )
 
   const trampoline = `@echo off\n"%~dp0\\${versionedPath}" %*`
-  const trampolinePath = Path.join(binPath, 'github.bat')
+  const trampolinePath = Path.join(binPath, 'github-desktop-plus-cli.bat')
 
   return writeFile(trampolinePath, trampoline)
 }
@@ -115,13 +115,13 @@ function writeShellScriptCLITrampoline(binPath: string): Promise<void> {
   // to resolve it. See https://github.com/desktop/desktop/issues/4998
   const versionedPath = resolveVersionedPath(
     binPath,
-    'resources/app/static/github.sh'
+    'resources/app/static/github-desktop-plus-cli.sh'
   ).replace(/\\/g, '/')
 
   const trampoline = `#!/usr/bin/env bash
   DIR="$( cd "$( dirname "\$\{BASH_SOURCE[0]\}" )" && pwd )"
   sh "$DIR/${versionedPath}" "$@"`
-  const trampolinePath = Path.join(binPath, 'github')
+  const trampolinePath = Path.join(binPath, 'github-desktop-plus-cli')
 
   return writeFile(trampolinePath, trampoline, { encoding: 'utf8', mode: 755 })
 }

--- a/app/static/win32/github-desktop-plus-cli.bat
+++ b/app/static/win32/github-desktop-plus-cli.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+set ELECTRON_RUN_AS_NODE=1
+call "%~dp0..\..\..\GitHubDesktopPlus.exe" "%~dp0..\cli.js" %*
+
+endlocal

--- a/app/static/win32/github-desktop-plus-cli.sh
+++ b/app/static/win32/github-desktop-plus-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
-ELECTRON="$CONTENTS/GitHubDesktop.exe"
+ELECTRON="$CONTENTS/GitHubDesktopPlus.exe"
 
 if grep -q Microsoft /proc/version; then
 	if [ -x /bin/wslpath ]; then

--- a/app/static/win32/github.bat
+++ b/app/static/win32/github.bat
@@ -1,7 +1,0 @@
-@echo off
-setlocal
-
-set ELECTRON_RUN_AS_NODE=1
-call "%~dp0..\..\..\GitHubDesktop.exe" "%~dp0..\cli.js" %*
-
-endlocal

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -33,7 +33,7 @@ export function getExecutableName() {
 }
 
 export function getOSXZipName() {
-  return `${productName}-${getDistArchitecture()}.zip`
+  return `GitHubDesktopPlus-v${version}-macOS-${getDistArchitecture()}.zip`
 }
 
 export function getOSXZipPath() {
@@ -42,7 +42,7 @@ export function getOSXZipPath() {
 
 export function getWindowsInstallerName() {
   const productName = getExecutableName()
-  return `${productName}Setup-${getDistArchitecture()}.msi`
+  return `${productName}-v${version}-windows-${getDistArchitecture()}.msi`
 }
 
 export function getWindowsInstallerPath() {
@@ -51,7 +51,7 @@ export function getWindowsInstallerPath() {
 
 export function getWindowsStandaloneName() {
   const productName = getExecutableName()
-  return `${productName}Setup-${getDistArchitecture()}.exe`
+  return `${productName}-v${version}-windows-${getDistArchitecture()}.exe`
 }
 
 export function getWindowsStandalonePath() {
@@ -64,7 +64,7 @@ export function getWindowsFullNugetPackageName(
   const architectureInfix = includeArchitecture
     ? `-${getDistArchitecture()}`
     : ''
-  return `${getWindowsIdentifierName()}-${version}${architectureInfix}-full.nupkg`
+  return `${getWindowsIdentifierName()}-v${version}${architectureInfix}-full.nupkg`
 }
 
 export function getWindowsFullNugetPackagePath() {
@@ -82,7 +82,7 @@ export function getWindowsDeltaNugetPackageName(
   const architectureInfix = includeArchitecture
     ? `-${getDistArchitecture()}`
     : ''
-  return `${getWindowsIdentifierName()}-${version}${architectureInfix}-delta.nupkg`
+  return `${getWindowsIdentifierName()}-v${version}${architectureInfix}-delta.nupkg`
 }
 
 export function getWindowsDeltaNugetPackagePath() {
@@ -95,7 +95,7 @@ export function getWindowsDeltaNugetPackagePath() {
 }
 
 export function getWindowsIdentifierName() {
-  return 'GitHubDesktop'
+  return 'GitHubDesktopPlus'
 }
 
 export function getBundleSizes() {
@@ -128,6 +128,16 @@ export function getDistArchitecture(): 'arm64' | 'x64' {
   // https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/
 
   return 'x64'
+}
+
+export function getArchitectureForFileName(): 'arm64' | 'x86_64' {
+  const arch = getDistArchitecture()
+  switch (arch) {
+    case 'arm64':
+      return 'arm64'
+    case 'x64':
+      return 'x86_64'
+  }
 }
 
 export function getUpdatesURL() {

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -1,4 +1,4 @@
-artifactName: 'GitHubDesktop-${os}-${arch}-${version}.${ext}'
+artifactName: 'GitHubDesktopPlus-${os}-${arch}-${version}.${ext}'
 linux:
   category: 'GNOME;GTK;Development'
   packageCategory: 'GNOME;GTK;Development'

--- a/script/package-debian.ts
+++ b/script/package-debian.ts
@@ -7,7 +7,11 @@ const globPromise = promisify(glob)
 import { rename } from 'fs-extra'
 
 import { getVersion } from '../app/package-info'
-import { getDistPath, getDistRoot } from './dist-info'
+import {
+  getDistPath,
+  getDistRoot,
+  getArchitectureForFileName,
+} from './dist-info'
 
 function getArchitecture() {
   const arch = process.env.npm_config_arch || process.arch
@@ -109,7 +113,7 @@ export async function packageDebian(): Promise<string> {
 
   const oldPath = files[0]
 
-  const newFileName = `GitHubDesktop-linux-${getArchitecture()}-${getVersion()}.deb`
+  const newFileName = `GitHubDesktopPlus-v${getVersion()}-linux-${getArchitectureForFileName()}.deb`
   const newPath = join(distRoot, newFileName)
   await rename(oldPath, newPath)
 

--- a/script/package-electron-builder.ts
+++ b/script/package-electron-builder.ts
@@ -7,7 +7,13 @@ import { promisify } from 'util'
 import glob = require('glob')
 const globPromise = promisify(glob)
 
-import { getDistPath, getDistRoot } from './dist-info'
+import {
+  getArchitectureForFileName,
+  getDistPath,
+  getDistRoot,
+} from './dist-info'
+import { rename } from 'fs/promises'
+import { getVersion } from '../app/package-info'
 
 function getArchitecture() {
   const arch = process.env.npm_config_arch || process.arch
@@ -19,7 +25,7 @@ function getArchitecture() {
   }
 }
 
-export async function packageElectronBuilder(): Promise<Array<string>> {
+export async function packageElectronBuilder(): Promise<string> {
   const distPath = getDistPath()
   const distRoot = getDistRoot()
 
@@ -48,7 +54,7 @@ export async function packageElectronBuilder(): Promise<Array<string>> {
     return Promise.reject(error)
   }
 
-  const appImageInstaller = `${distRoot}/GitHubDesktop-linux-*.AppImage`
+  const appImageInstaller = `${distRoot}/GitHubDesktopPlus-linux-*.AppImage`
 
   const files = await globPromise(appImageInstaller)
   if (files.length !== 1) {
@@ -59,7 +65,11 @@ export async function packageElectronBuilder(): Promise<Array<string>> {
     )
   }
 
-  const appImageInstallerPath = files[0]
+  const oldPath = files[0]
 
-  return Promise.resolve([appImageInstallerPath])
+  const newFileName = `GitHubDesktopPlus-v${getVersion()}-linux-${getArchitectureForFileName()}.AppImage`
+  const newPath = path.join(distRoot, newFileName)
+  await rename(oldPath, newPath)
+
+  return Promise.resolve(newPath)
 }

--- a/script/package-redhat.ts
+++ b/script/package-redhat.ts
@@ -7,7 +7,11 @@ const globPromise = promisify(glob)
 import { rename } from 'fs-extra'
 
 import { getVersion } from '../app/package-info'
-import { getDistPath, getDistRoot } from './dist-info'
+import {
+  getArchitectureForFileName,
+  getDistPath,
+  getDistRoot,
+} from './dist-info'
 
 function getArchitecture() {
   const arch = process.env.npm_config_arch || process.arch
@@ -102,7 +106,7 @@ export async function packageRedhat(): Promise<string> {
 
   const oldPath = files[0]
 
-  const newFileName = `GitHubDesktop-linux-${getArchitecture()}-${getVersion()}.rpm`
+  const newFileName = `GitHubDesktopPlus-v${getVersion()}-linux-${getArchitectureForFileName()}.rpm`
   const newPath = join(distRoot, newFileName)
   await rename(oldPath, newPath)
 

--- a/script/package.ts
+++ b/script/package.ts
@@ -155,7 +155,7 @@ function packageWindows() {
         )
         const to = join(
           outputDir,
-          `${getWindowsIdentifierName()}-${getVersion()}-${arch}-${kind}.nupkg`
+          `${getWindowsIdentifierName()}-v${getVersion()}-${arch}-${kind}.nupkg`
         )
 
         console.log(`Renaming ${from} to ${to}`)
@@ -221,11 +221,11 @@ async function packageLinux() {
     await chmod(helperPath, 0o4755)
   }
   try {
-    const files = await packageElectronBuilder()
+    const appImagePackage = await packageElectronBuilder()
     const debianPackage = await packageDebian()
     const redhatPackage = await packageRedhat()
 
-    const installers = [...files, debianPackage, redhatPackage]
+    const installers = [appImagePackage, debianPackage, redhatPackage]
 
     console.log(`Installers created:`)
     for (const installer of installers) {


### PR DESCRIPTION
Update getWindowsIdentifierName() to GitHubDesktopPlus.
Also, use correct name for generated binaries so that we don't need to rename them again in the CI/CD pipeline.
