### PR TITLE
Update App User Model ID to GitHubDesktopPlus

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -122,7 +122,7 @@ if (__DARWIN__) {
 // On Windows, in order to get notifications properly working for dev builds,
 // we'll want to set the right App User Model ID from production builds.
 if (__WIN32__ && __DEV__) {
-  app.setAppUserModelId('com.squirrel.GitHubDesktop.GitHubDesktop')
+  app.setAppUserModelId('com.squirrel.GitHubDesktopPlus.GitHubDesktopPlus')
 }
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
- Updates the Windows App User Model ID from `com.squirrel.GitHubDesktop.GitHubDesktop` to `com.squirrel.GitHubDesktopPlus.GitHubDesktopPlus` in dev builds
- The main install path fix was already done in PR #83 (changing `getWindowsIdentifierName()`). This is a minor follow-up to align the dev build App User Model ID, which Windows uses for taskbar grouping and notifications

Related to #82 (main fix in #83)

## Test plan
- [ ] Build a Windows dev build and verify notifications and taskbar identity don't conflict with original GitHub Desktop