### PR TITLE
Add keywords to .desktop entries.

### DIFF
--- a/publish/aur/github-desktop-plus.desktop
+++ b/publish/aur/github-desktop-plus.desktop
@@ -9,3 +9,4 @@ Type=Application
 Icon=github-desktop-plus
 Categories=Development;
 MimeType=x-scheme-handler/x-github-client;x-scheme-handler/x-github-desktop-auth;x-scheme-handler/x-github-desktop-dev-auth;
+Keywords=git;github;gitlab;bitbucket;

--- a/publish/flatpak/io.github.pol_rivero.github-desktop-plus.desktop
+++ b/publish/flatpak/io.github.pol_rivero.github-desktop-plus.desktop
@@ -7,3 +7,4 @@ Type=Application
 Terminal=false
 MimeType=x-scheme-handler/x-github-client;x-scheme-handler/x-github-desktop-auth;x-scheme-handler/x-github-desktop-dev-auth;
 Categories=Development;
+Keywords=git;github;gitlab;bitbucket;


### PR DESCRIPTION
## Description
On the GNOME desktop it's often convenient to access apps by keyword search (super key + text search). This alters the .desktop files to include common keywords (git, github, gitlab, bitbucket), so that all of these search terms will return Desktop-Plus.

### Screenshots

<img width="478" height="271" alt="image" src="https://github.com/user-attachments/assets/02d61fbf-a1ad-4522-953e-afabad8430e4" />
