### PR TITLE
fix: fetch before merging in Update from Default Branch

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -640,7 +640,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     // Disable autoupdates so that the app doesn't revert to the desktop/desktop upstream whenever there is an update.
   }
 
-  private updateBranchWithContributionTargetBranch() {
+  private async updateBranchWithContributionTargetBranch() {
     const { selectedState } = this.state
     if (
       selectedState == null ||
@@ -658,6 +658,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (!contributionTargetDefaultBranch) {
       return
     }
+
+    await this.props.dispatcher.fetch(repository, FetchType.UserInitiatedTask)
 
     this.props.dispatcher.initializeMergeOperation(
       repository,


### PR DESCRIPTION
## Summary

Closes #110

- Adds `await this.props.dispatcher.fetch(repository, FetchType.UserInitiatedTask)` before the `mergeBranch` call in `updateBranchWithContributionTargetBranch()`.
- Makes the method `async` to allow awaiting the fetch.
- `FetchType` was already imported; no additional imports needed.

## Root cause

`updateBranchWithContributionTargetBranch()` merged directly against the local ref for the default branch without fetching from remote first. If the local ref was stale, git would correctly report "already up to date" relative to the cached local state — even though the remote had new commits.

## Test plan

- [ ] Click **Branch > Update from Main** when the remote default branch has unpulled commits — confirm the fetch runs and the merge succeeds.
- [ ] Click **Branch > Update from Main** when the branch is genuinely up to date — confirm the app correctly reports "already up to date".