### PR TITLE
feat: update from origin/main without altering local branches

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2908,9 +2908,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     let contributionTargetDefaultBranch: string | undefined
     if (selectedRepository instanceof Repository) {
+      const targetBranch = findContributionTargetDefaultBranch(
+        selectedRepository,
+        branchesState
+      )
+      // Show the remote tracking branch name (e.g. "origin/main") in the
+      // menu label, since we merge from the remote ref, not the local one.
       contributionTargetDefaultBranch =
-        findContributionTargetDefaultBranch(selectedRepository, branchesState)
-          ?.name ?? undefined
+        targetBranch !== null
+          ? targetBranch.upstream ?? targetBranch.name
+          : undefined
     }
 
     // From the menu, we'll offer to force-push whenever it's possible, regardless
@@ -5898,6 +5905,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
+   * Fetch all relevant remotes without fast-forwarding local branches.
+   *
+   * This updates remote tracking refs (e.g. origin/main) but leaves local
+   * branches untouched. Useful when you only need to merge from a remote
+   * ref without altering the local branch state.
+   */
+  public _fetchWithoutFastForward(
+    repository: Repository,
+    fetchType: FetchType
+  ): Promise<void> {
+    return this.withRefreshedGitHubRepository(repository, repository => {
+      return this.performFetch(repository, fetchType, undefined, true)
+    })
+  }
+
+  /**
    * Fetch a particular remote in a repository.
    *
    * Note that this method will not perform the fetch of the specified remote
@@ -5923,7 +5946,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private async performFetch(
     repository: Repository,
     fetchType: FetchType,
-    remotes?: IRemote[]
+    remotes?: IRemote[],
+    skipFastForward?: boolean
   ): Promise<void> {
     await this.withPushPullFetch(repository, async () => {
       const gitStore = this.gitStoreCache.get(repository)
@@ -5954,14 +5978,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
           ? 'Refreshing Repository'
           : 'Refreshing repository'
 
-        this.updatePushPullFetchProgress(repository, {
-          kind: 'generic',
-          title: refreshTitle,
-          description: 'Fast-forwarding branches',
-          value: fetchWeight,
-        })
+        if (!skipFastForward) {
+          this.updatePushPullFetchProgress(repository, {
+            kind: 'generic',
+            title: refreshTitle,
+            description: 'Fast-forwarding branches',
+            value: fetchWeight,
+          })
 
-        await this.fastForwardBranches(repository)
+          await this.fastForwardBranches(repository)
+        }
 
         this.updatePushPullFetchProgress(repository, {
           kind: 'generic',

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -29,7 +29,7 @@ import {
   getNonGitHubUrl,
   isRepositoryWithGitHubRepository,
 } from '../models/repository'
-import { Branch } from '../models/branch'
+import { Branch, BranchType } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
 import { Account, isDotComAccount } from '../models/account'
@@ -659,19 +659,54 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    await this.props.dispatcher.fetch(repository, FetchType.UserInitiatedTask)
+    // Fetch from the remote to update the remote tracking ref (e.g.
+    // origin/main) without fast-forwarding local branches.
+    await this.props.dispatcher.fetchWithoutFastForward(
+      repository,
+      FetchType.UserInitiatedTask
+    )
+
+    // Merge the remote tracking branch (e.g. origin/main) instead of the
+    // local branch, so that the local default branch is not altered as a
+    // side effect.
+    const branchToMerge = this.getRemoteTrackingBranch(
+      contributionTargetDefaultBranch,
+      state.branchesState.allBranches
+    )
 
     this.props.dispatcher.initializeMergeOperation(
       repository,
       false,
-      contributionTargetDefaultBranch
+      branchToMerge
     )
 
     const { mergeStatus } = state.compareState
-    this.props.dispatcher.mergeBranch(
-      repository,
-      contributionTargetDefaultBranch,
-      mergeStatus
+    this.props.dispatcher.mergeBranch(repository, branchToMerge, mergeStatus)
+  }
+
+  /**
+   * Returns the remote tracking branch for a given branch if available.
+   * For remote branches, returns the branch itself.
+   * For local branches, finds the corresponding remote branch in allBranches.
+   * Falls back to the original branch if no remote tracking branch is found.
+   */
+  private getRemoteTrackingBranch(
+    branch: Branch,
+    allBranches: ReadonlyArray<Branch>
+  ): Branch {
+    if (branch.type === BranchType.Remote) {
+      return branch
+    }
+
+    const upstream = branch.upstream
+    if (upstream === null) {
+      return branch
+    }
+
+    return (
+      allBranches.find(
+        b => b.type === BranchType.Remote && b.name === upstream
+      ) ?? branch
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -788,6 +788,17 @@ export class Dispatcher {
     return this.appStore._fetch(repository, fetchType)
   }
 
+  /**
+   * Fetch all refs without fast-forwarding local branches.
+   * Updates remote tracking refs only, leaving local branches untouched.
+   */
+  public fetchWithoutFastForward(
+    repository: Repository,
+    fetchType: FetchType
+  ): Promise<void> {
+    return this.appStore._fetchWithoutFastForward(repository, fetchType)
+  }
+
   /** Publish the repository to GitHub with the given properties. */
   public publishRepository(
     repository: Repository,


### PR DESCRIPTION
## Summary

Follow-up to #111 as [suggested by @pol-rivero](https://github.com/pol-rivero/github-desktop-plus/pull/111#issuecomment-4147797456).

After PR #111 added a fetch before the merge, `performFetch` also fast-forwards local branches as a side effect.
By merging `origin/main directly` (instead of local main) and skipping the fast-forward step, we avoid unintended changes to local branches.

So, instead of merging the local default branch (e.g. `main`), with this PR it merges the remote tracking branch (e.g. `origin/main`) directly. This means the "Update from Default Branch" action no longer alters local branches as a side effect. The menu label now reflects this (e.g. "Update from origin/main").

## Changes

### `app/src/ui/app.tsx`

- Made `updateBranchWithContributionTargetBranch()` `async` so it can `await` the fetch before merging.
- After fetching, resolves the remote tracking branch (e.g. `origin/main`) from `allBranches` and merges that instead of the local branch. Falls back to the local branch if no remote tracking branch is found.
- Added `getRemoteTrackingBranch()` helper: for remote branches (fork case) returns the branch as-is; for local branches, looks up the corresponding remote branch via the `upstream` field.

### `app/src/ui/dispatcher/dispatcher.ts`

- Added `fetchWithoutFastForward()`: exposes the new app-store method to the UI layer.

### `app/src/lib/stores/app-store.ts`

- Added `skipFastForward` parameter to `performFetch()`. When `true`, skips the `fastForwardBranches()` call so local branches are not altered.
- Added `_fetchWithoutFastForward()` public method that calls `performFetch` with `skipFastForward: true`.
- Updated the menu label source to use the branch's `upstream` name (e.g. `origin/main`) instead of the local name (e.g. `main`), so the menu reads "Update from origin/main".

## Test plan

- [ ] Click **Branch > Update from origin/main** when the remote default branch has unpulled commits. Confirm the fetch runs and the merge succeeds.
- [ ] Click **Branch > Update from origin/main** when the branch is genuinely up to date. Confirm the app correctly reports "already up to date".
- [ ] Verify the local `main` branch is NOT fast-forwarded after the operation.
- [ ] Verify the menu label shows "Update from origin/main" (or the appropriate remote branch name).
- [ ] For fork repos contributing to parent: verify the menu shows "Update from upstream/main" and merges the upstream remote branch.