### PR TITLE
Fix CLI install to it points to github-desktop-plus-cli.sh

### DIFF
--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -7,7 +7,7 @@ import { mkdir, readlink, symlink, unlink } from 'fs/promises'
 export const InstalledCLIPath = '/usr/local/bin/github'
 
 /** The path to the packaged CLI. */
-const PackagedPath = Path.resolve(__dirname, 'static', 'github.sh')
+const PackagedPath = Path.resolve(__dirname, 'static', 'github-desktop-plus-cli.sh')
 
 /** Install the command line tool on macOS. */
 export async function installCLI(): Promise<void> {


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- install CLI was pointing to `static/github.sh` but it should point to `static/github-desktop-plus-cli.sh`
