### PR TITLE
feat: add visual warning for mismatched commit email

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -94,10 +94,34 @@ function formatConfigOriginTooltip(
   fieldName: string,
   origin: IConfigValueOrigin,
   repositoryPath: string,
-  onRevealFile: () => void
+  onRevealFile: () => void,
+  warningMessage?: string,
+  warningAccountLogin?: string,
+  onOpenRepositoryRemoteSettings?: () => void
 ): JSX.Element {
   return (
     <div className="config-origin-tooltip">
+      {warningMessage && warningAccountLogin && (
+        <>
+          <span className="config-origin-tooltip-warning-icon">
+            <Octicon symbol={octicons.alert} />
+          </span>
+          <span className="config-origin-tooltip-warning">
+            {warningMessage}
+          </span>
+          <span className="config-origin-tooltip-spacer" />
+          <span className="config-origin-tooltip-hint">
+            Repository is linked to @{warningAccountLogin}
+          </span>
+          <span className="config-origin-tooltip-spacer" />
+          <span className="config-origin-tooltip-hint">
+            Change account in{' '}
+            <LinkButton onClick={onOpenRepositoryRemoteSettings}>
+              repository settings
+            </LinkButton>
+          </span>
+        </>
+      )}
       <span className="config-origin-tooltip-label">{fieldName}:</span>
       <span>{origin.value}</span>
       <span className="config-origin-tooltip-label">Scope:</span>
@@ -842,6 +866,13 @@ export class CommitMessage extends React.Component<
 
     const { commitAuthorNameOrigin, commitAuthorEmailOrigin } = this.props
     const repoPath = this.props.repository.path
+    const isMisattributed = warningType === 'misattribution'
+    const warningMessage = isMisattributed
+      ? 'Email does not match linked account'
+      : undefined
+    const warningAccountLogin = isMisattributed
+      ? repositoryAccount?.login
+      : undefined
     const nameTooltip = commitAuthorNameOrigin
       ? formatConfigOriginTooltip(
           'Name',
@@ -855,12 +886,22 @@ export class CommitMessage extends React.Component<
           'Email',
           commitAuthorEmailOrigin,
           repoPath,
-          this.onRevealEmailConfigFile
+          this.onRevealEmailConfigFile,
+          warningMessage,
+          warningAccountLogin,
+          this.onOpenRepositoryRemoteSettings
         )
       : undefined
 
+    const identityClasses = classNames('commit-author-identity', {
+      warning: isMisattributed,
+    })
+    const emailClasses = classNames('commit-author-email', {
+      warning: isMisattributed,
+    })
+
     return (
-      <div className="commit-author-identity">
+      <div className={identityClasses}>
         {avatar}
         <div className="commit-author-info">
           <TooltippedContent
@@ -872,7 +913,7 @@ export class CommitMessage extends React.Component<
             {commitAuthor.name}
           </TooltippedContent>
           <TooltippedContent
-            className="commit-author-email"
+            className={emailClasses}
             tooltip={emailTooltip}
             tooltipClassName="config-origin"
             interactive={true}
@@ -912,6 +953,14 @@ export class CommitMessage extends React.Component<
       type: PopupType.RepositorySettings,
       repository: this.props.repository,
       initialSelectedTab: RepositorySettingsTab.GitConfig,
+    })
+  }
+
+  private onOpenRepositoryRemoteSettings = () => {
+    this.props.onShowPopup({
+      type: PopupType.RepositorySettings,
+      repository: this.props.repository,
+      initialSelectedTab: RepositorySettingsTab.Remote,
     })
   }
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -87,6 +87,11 @@
     gap: var(--spacing-half);
     margin-bottom: var(--spacing-half);
 
+    &.warning {
+      border-left: 2px solid var(--input-icon-warning-color);
+      padding-left: var(--spacing-half);
+    }
+
     .commit-author-info {
       display: flex;
       flex-direction: column;
@@ -105,6 +110,10 @@
         color: var(--text-secondary-color);
         @include ellipsis;
         cursor: default;
+
+        &.warning {
+          color: var(--input-warning-text-color);
+        }
       }
     }
   }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -222,6 +222,28 @@ body > .tooltip,
         font-weight: bold;
         text-align: right;
       }
+
+      .config-origin-tooltip-warning-icon {
+        color: var(--input-icon-warning-color);
+        grid-row: span 3;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .config-origin-tooltip-warning {
+        color: var(--input-icon-warning-color);
+        font-size: var(--font-size-sm);
+      }
+
+      .config-origin-tooltip-spacer {
+        // Empty first-column cell in the warning grid rows
+      }
+
+      .config-origin-tooltip-hint {
+        font-size: var(--font-size-xs);
+        color: var(--input-icon-warning-color);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

When the commit email doesn't match the linked account, the existing warning is easy to miss - it's just a small yellow triangle on the avatar. First-time users especially have no idea what it means or what to do about it.

This PR makes the misattribution warning more noticeable and actionable:
1) More visible:
- Added a yellow accent line on the left side of the commit author area
- The email text turns yellow to draw attention

2) More helpful tooltip:
- Shows a clear message: "Email does not match linked account"
- Hints which account the repository is currently linked to
- Provides a direct link to repository settings where the user can fix it

The goal is simple - when this mismatch happens, users should notice it faster and understand what to do without guessing.

### Screenshots

#### 1. Before changes
Only a small triangle icon on the avatar, no explanation of what's wrong or how to fix it

<img height="250"  alt="image" src="https://github.com/user-attachments/assets/f53bcff8-fe8d-468d-a635-5ee4623130c0" />

#### 2. After changes

(1) yellow accent line
(2) colored email make the warning visible at a glance
(3) and the tooltip explains the problem with a link to fix it
(4) Action text and direct link to place in settings

<img height="250"  alt="image" src="https://github.com/user-attachments/assets/a5314423-1417-4c0c-9a0e-00a4fe3b0e03" />

How to reproduce:

- Sign in with your GitHub account
- Open a repository linked to that account
- Set a different email in git config (e.g. git config user.email "other@example.com")
- Go to the Changes tab - the warning should appear in the commit author area
- Hover over the email to see the tooltip with details


## Release notes

Notes: When commit email doesn't match the linked repository account, the warning is now more visible with a yellow accent line and colored email text. The tooltip explains the issue and links directly to repository settings.
