### PR TITLE
feat(worktrees): support .worktreeinclude for copying gitignored files

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "chalk": "^2.3.0",
     "classnames": "^2.2.5",
     "codemirror": "^5.65.17",
+    "ignore": "^7.0.5",
     "codemirror-mode-elixir": "^1.1.2",
     "codemirror-mode-luau": "^1.0.2",
     "codemirror-mode-zig": "^1.0.7",

--- a/app/src/lib/git/worktree-include.ts
+++ b/app/src/lib/git/worktree-include.ts
@@ -59,7 +59,7 @@ export async function getIgnoredFilesMatchingPatterns(
   // Files are NUL-separated; filter out empty entries from the split
   const ignoredFiles = result.stdout.split('\0').filter(f => f.length > 0)
 
-  const ig = ignore().add(patterns as string[])
+  const ig = ignore().add(patterns)
   return ignoredFiles.filter(f => ig.ignores(f))
 }
 

--- a/app/src/lib/git/worktree-include.ts
+++ b/app/src/lib/git/worktree-include.ts
@@ -1,0 +1,146 @@
+import * as Fs from 'fs'
+import * as Path from 'path'
+import { readFile, copyFile, mkdir } from 'fs/promises'
+import ignore from 'ignore'
+import type { Repository } from '../../models/repository'
+import { git } from './core'
+import { addWorktree, getMainWorktreePath } from './worktree'
+
+const WorktreeIncludeFile = '.worktreeinclude'
+
+/**
+ * Reads the patterns from the `.worktreeinclude` file at the root of the
+ * given repository path.
+ *
+ * The file uses `.gitignore` syntax. Blank lines and lines starting with `#`
+ * are ignored.
+ *
+ * Returns an empty array if the file does not exist.
+ */
+export async function readWorktreeIncludePatterns(
+  repositoryPath: string
+): Promise<ReadonlyArray<string>> {
+  const filePath = Path.join(repositoryPath, WorktreeIncludeFile)
+
+  let contents: string
+  try {
+    contents = await readFile(filePath, 'utf8')
+  } catch {
+    return []
+  }
+
+  return contents
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('#'))
+}
+
+/**
+ * Returns the list of gitignored files in `repositoryPath` that match any of
+ * the given patterns.
+ *
+ * Only files that are both gitignored **and** matched by a `.worktreeinclude`
+ * pattern are returned — tracked files are never included.
+ */
+export async function getIgnoredFilesMatchingPatterns(
+  repository: Repository,
+  patterns: ReadonlyArray<string>
+): Promise<ReadonlyArray<string>> {
+  if (patterns.length === 0) {
+    return []
+  }
+
+  const result = await git(
+    ['ls-files', '--others', '--ignored', '--exclude-standard', '-z'],
+    repository.path,
+    'getIgnoredFiles'
+  )
+
+  // Files are NUL-separated; filter out empty entries from the split
+  const ignoredFiles = result.stdout.split('\0').filter(f => f.length > 0)
+
+  const ig = ignore().add(patterns as string[])
+  return ignoredFiles.filter(f => ig.ignores(f))
+}
+
+/**
+ * Copies each file in `files` (relative paths) from `sourcePath` to
+ * `destinationPath`, preserving the directory structure.
+ *
+ * Files that cannot be copied (e.g. because they no longer exist at the
+ * source) are skipped silently — a failure to copy a single file never
+ * prevents the others from being copied.
+ */
+export async function copyWorktreeIncludeFiles(
+  sourcePath: string,
+  destinationPath: string,
+  files: ReadonlyArray<string>
+): Promise<void> {
+  for (const file of files) {
+    const src = Path.join(sourcePath, file)
+    const dest = Path.join(destinationPath, file)
+
+    // Guard against path traversal: the resolved destination must be
+    // inside the worktree directory.
+    const resolvedDest = Path.resolve(dest)
+    const resolvedWorktreeRoot = Path.resolve(destinationPath)
+    if (!resolvedDest.startsWith(resolvedWorktreeRoot + Path.sep)) {
+      continue
+    }
+
+    try {
+      // eslint-disable-next-line no-sync
+      if (!Fs.existsSync(src)) {
+        continue
+      }
+
+      await mkdir(Path.dirname(dest), { recursive: true })
+      await copyFile(src, dest)
+    } catch (e) {
+      log.warn(
+        `[worktree-include] Failed to copy '${file}' to worktree`,
+        e instanceof Error ? e : undefined
+      )
+    }
+  }
+}
+
+/**
+ * Creates a new git worktree and then copies any gitignored files listed in
+ * the `.worktreeinclude` file from the main worktree into the newly created
+ * worktree.
+ *
+ * The copy step is best-effort: failures are logged but do not prevent the
+ * worktree from being used.
+ *
+ * @param repository  The repository to create the worktree in.
+ * @param path        The absolute path where the new worktree should be created.
+ * @param options     Options forwarded to `addWorktree`.
+ */
+export async function addWorktreeWithIncludes(
+  repository: Repository,
+  path: string,
+  options: Parameters<typeof addWorktree>[2] = {}
+): Promise<void> {
+  await addWorktree(repository, path, options)
+
+  try {
+    const mainPath = (await getMainWorktreePath(repository)) ?? repository.path
+    const patterns = await readWorktreeIncludePatterns(mainPath)
+
+    if (patterns.length === 0) {
+      return
+    }
+
+    const files = await getIgnoredFilesMatchingPatterns(repository, patterns)
+
+    if (files.length > 0) {
+      await copyWorktreeIncludeFiles(mainPath, path, files)
+    }
+  } catch (e) {
+    log.warn(
+      '[worktree-include] Failed to process .worktreeinclude; worktree was still created',
+      e instanceof Error ? e : undefined
+    )
+  }
+}

--- a/app/src/ui/worktrees/add-worktree-dialog.tsx
+++ b/app/src/ui/worktrees/add-worktree-dialog.tsx
@@ -10,7 +10,7 @@ import { Button } from '../lib/button'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { showOpenDialog } from '../main-process-proxy'
-import { addWorktree } from '../../lib/git/worktree'
+import { addWorktreeWithIncludes } from '../../lib/git/worktree-include'
 
 interface IAddWorktreeDialogProps {
   readonly repository: Repository
@@ -72,7 +72,7 @@ export class AddWorktreeDialog extends React.Component<
     const worktreePath = Path.join(path, branchName)
 
     try {
-      await addWorktree(this.props.repository, worktreePath, {
+      await addWorktreeWithIncludes(this.props.repository, worktreePath, {
         createBranch: branchName.length > 0 ? branchName : undefined,
       })
     } catch (e) {

--- a/app/test/unit/git/worktree-include-test.ts
+++ b/app/test/unit/git/worktree-include-test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { mkdir, writeFile, readFile } from 'fs/promises'
+import { existsSync } from 'fs'
+import * as Path from 'path'
+import { exec } from 'dugite'
+
+import {
+  readWorktreeIncludePatterns,
+  getIgnoredFilesMatchingPatterns,
+  copyWorktreeIncludeFiles,
+} from '../../../src/lib/git/worktree-include'
+import { createTempDirectory } from '../../helpers/temp'
+import { setupEmptyRepository } from '../../helpers/repositories'
+
+describe('git/worktree-include', () => {
+  describe('readWorktreeIncludePatterns', () => {
+    it('returns empty array when file does not exist', async t => {
+      const dir = await createTempDirectory(t)
+      const patterns = await readWorktreeIncludePatterns(dir)
+      assert.deepStrictEqual(patterns, [])
+    })
+
+    it('parses patterns from file', async t => {
+      const dir = await createTempDirectory(t)
+      await writeFile(
+        Path.join(dir, '.worktreeinclude'),
+        '.env\n.env.local\nconfig/secrets.json\n'
+      )
+      const patterns = await readWorktreeIncludePatterns(dir)
+      assert.deepStrictEqual(patterns, [
+        '.env',
+        '.env.local',
+        'config/secrets.json',
+      ])
+    })
+
+    it('skips blank lines and comments', async t => {
+      const dir = await createTempDirectory(t)
+      await writeFile(
+        Path.join(dir, '.worktreeinclude'),
+        '# This is a comment\n\n.env\n\n# Another comment\n.env.local\n'
+      )
+      const patterns = await readWorktreeIncludePatterns(dir)
+      assert.deepStrictEqual(patterns, ['.env', '.env.local'])
+    })
+
+    it('returns empty array for a file with only comments and blanks', async t => {
+      const dir = await createTempDirectory(t)
+      await writeFile(Path.join(dir, '.worktreeinclude'), '# comment\n\n   \n')
+      const patterns = await readWorktreeIncludePatterns(dir)
+      assert.deepStrictEqual(patterns, [])
+    })
+  })
+
+  describe('getIgnoredFilesMatchingPatterns', () => {
+    it('returns empty array when patterns is empty', async t => {
+      const repo = await setupEmptyRepository(t)
+      const files = await getIgnoredFilesMatchingPatterns(repo, [])
+      assert.deepStrictEqual(files, [])
+    })
+
+    it('returns gitignored files matching the patterns', async t => {
+      const repo = await setupEmptyRepository(t)
+
+      await exec(['config', 'user.email', 'test@example.com'], repo.path)
+      await exec(['config', 'user.name', 'Test User'], repo.path)
+
+      await writeFile(Path.join(repo.path, '.gitignore'), '.env\n')
+      await exec(['add', '.gitignore'], repo.path)
+      await exec(['commit', '-m', 'add gitignore'], repo.path)
+
+      await writeFile(Path.join(repo.path, '.env'), 'SECRET=value\n')
+      await writeFile(Path.join(repo.path, 'readme.txt'), 'hello\n')
+      await exec(['add', 'readme.txt'], repo.path)
+
+      const files = await getIgnoredFilesMatchingPatterns(repo, ['.env'])
+      assert.deepStrictEqual(files, ['.env'])
+    })
+
+    it('does not return tracked files even if pattern matches', async t => {
+      const repo = await setupEmptyRepository(t)
+      await exec(['config', 'user.email', 'test@example.com'], repo.path)
+      await exec(['config', 'user.name', 'Test User'], repo.path)
+
+      await writeFile(Path.join(repo.path, '.gitignore'), '')
+      await writeFile(Path.join(repo.path, 'tracked.txt'), 'content\n')
+      await exec(['add', 'tracked.txt', '.gitignore'], repo.path)
+      await exec(['commit', '-m', 'initial'], repo.path)
+
+      const files = await getIgnoredFilesMatchingPatterns(repo, ['tracked.txt'])
+      assert.deepStrictEqual(files, [])
+    })
+
+    it('does not return gitignored files that do not match the pattern', async t => {
+      const repo = await setupEmptyRepository(t)
+      await exec(['config', 'user.email', 'test@example.com'], repo.path)
+      await exec(['config', 'user.name', 'Test User'], repo.path)
+
+      await writeFile(
+        Path.join(repo.path, '.gitignore'),
+        '.env\nsecrets.json\n'
+      )
+      await exec(['add', '.gitignore'], repo.path)
+      await exec(['commit', '-m', 'gitignore'], repo.path)
+
+      await writeFile(Path.join(repo.path, '.env'), 'SECRET=1\n')
+      await writeFile(Path.join(repo.path, 'secrets.json'), '{}')
+
+      const files = await getIgnoredFilesMatchingPatterns(repo, ['.env'])
+      assert.deepStrictEqual(files, ['.env'])
+    })
+  })
+
+  describe('copyWorktreeIncludeFiles', () => {
+    it('copies files preserving directory structure', async t => {
+      const source = await createTempDirectory(t)
+      const dest = await createTempDirectory(t)
+
+      await mkdir(Path.join(source, 'config'), { recursive: true })
+      await writeFile(Path.join(source, '.env'), 'SECRET=1\n')
+      await writeFile(Path.join(source, 'config', 'secrets.json'), '{}')
+
+      await copyWorktreeIncludeFiles(source, dest, [
+        '.env',
+        'config/secrets.json',
+      ])
+
+      const envContent = await readFile(Path.join(dest, '.env'), 'utf8')
+      assert.strictEqual(envContent, 'SECRET=1\n')
+
+      const secretsContent = await readFile(
+        Path.join(dest, 'config', 'secrets.json'),
+        'utf8'
+      )
+      assert.strictEqual(secretsContent, '{}')
+    })
+
+    it('skips files that do not exist at the source', async t => {
+      const source = await createTempDirectory(t)
+      const dest = await createTempDirectory(t)
+
+      await writeFile(Path.join(source, '.env'), 'SECRET=1\n')
+
+      await copyWorktreeIncludeFiles(source, dest, ['.env', 'missing.txt'])
+
+      assert.ok(existsSync(Path.join(dest, '.env')))
+      assert.ok(!existsSync(Path.join(dest, 'missing.txt')))
+    })
+
+    it('does not copy files with path traversal patterns', async t => {
+      const source = await createTempDirectory(t)
+      const dest = await createTempDirectory(t)
+
+      await writeFile(Path.join(source, '.env'), 'SECRET=1\n')
+
+      await copyWorktreeIncludeFiles(source, dest, ['../../../etc/passwd'])
+
+      const destContents = await import('fs/promises').then(fs =>
+        fs.readdir(dest)
+      )
+      assert.strictEqual(destContents.length, 0)
+    })
+  })
+})

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -900,6 +900,11 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #126

## Description
When creating a new worktree, automatically copy gitignored files listed in a .worktreeinclude file (gitignore syntax) from the main worktree into the new worktree. Only files that are both gitignored and matched by a pattern are copied — tracked files are never duplicated.

- Add `addWorktreeWithIncludes()` which wraps `addWorktree()` with a best-effort post-creation copy step
- Add `readWorktreeIncludePatterns()` to parse the .worktreeinclude file
- Add `getIgnoredFilesMatchingPatterns()` using `git ls-files --others --ignored` and the `ignore` npm package for .gitignore-spec matching
- Add `copyWorktreeIncludeFiles()` with path-traversal protection
- Wire AddWorktreeDialog to use `addWorktreeWithIncludes`
- Add `ignore` ^7.0.5 as a dependency
- Add 11 unit tests covering all new functions
### Screenshots
<img width="1922" height="1310" alt="Screenshot 2026-04-08 at 9 34 57 PM" src="https://github.com/user-attachments/assets/d410e3a1-9777-4d0e-b27c-d3c27f98bd09" />
<img width="709" height="497" alt="Screenshot 2026-04-08 at 9 35 33 PM" src="https://github.com/user-attachments/assets/edbe6f3c-79ee-45f2-9b5d-1c196c3bef2d" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
