### PR TITLE
Add option to fetch others/remote branches from the branch dropdown context menu

### DIFF
--- a/app/src/lib/progress/fetch.ts
+++ b/app/src/lib/progress/fetch.ts
@@ -26,7 +26,7 @@ export class FetchProgressParser extends GitProgressParser {
  * Highly approximate (some would say outright inaccurate) division
  * of the individual progress reporting steps in a fetch operation
  */
-const remoteOrLocalBranchFetchSteps = [
+const singleBranchFetchSteps = [
   { title: 'remote: Counting objects', weight: 0.4 },
   { title: 'remote: Compressing objects', weight: 0.6 },
 ]
@@ -36,8 +36,8 @@ const remoteOrLocalBranchFetchSteps = [
  * `git fetch --progress <remote> <branch>` and turning that into a percentage
  * value estimating the overall progress of a single branch fetch.
  */
-export class RemoteOrLocalBranchFetchProgressParser extends GitProgressParser {
+export class SingleBranchFetchProgressParser extends GitProgressParser {
   public constructor() {
-    super(remoteOrLocalBranchFetchSteps)
+    super(singleBranchFetchSteps)
   }
 }

--- a/app/src/lib/progress/fetch.ts
+++ b/app/src/lib/progress/fetch.ts
@@ -27,8 +27,10 @@ export class FetchProgressParser extends GitProgressParser {
  * of the individual progress reporting steps in a fetch operation
  */
 const singleBranchFetchSteps = [
-  { title: 'remote: Counting objects', weight: 0.4 },
-  { title: 'remote: Compressing objects', weight: 0.6 },
+  { title: 'remote: Enumerating objects', weight: 0.1 },
+  { title: 'remote: Counting objects', weight: 0.2 },
+  { title: 'remote: Compressing objects', weight: 0.3 },
+  { title: 'remote', weight: 0.4 },
 ]
 
 /**

--- a/app/src/lib/progress/fetch.ts
+++ b/app/src/lib/progress/fetch.ts
@@ -20,3 +20,24 @@ export class FetchProgressParser extends GitProgressParser {
     super(steps)
   }
 }
+
+/**
+ * Progress steps for a single-branch fetch operation. Unlike a full fetch,
+ * Highly approximate (some would say outright inaccurate) division
+ * of the individual progress reporting steps in a fetch operation
+ */
+const remoteOrLocalBranchFetchSteps = [
+  { title: 'remote: Counting objects', weight: 0.4 },
+  { title: 'remote: Compressing objects', weight: 0.6 },
+]
+
+/**
+ * A utility class for interpreting the output from
+ * `git fetch --progress <remote> <branch>` and turning that into a percentage
+ * value estimating the overall progress of a single branch fetch.
+ */
+export class RemoteOrLocalBranchFetchProgressParser extends GitProgressParser {
+  public constructor() {
+    super(remoteOrLocalBranchFetchSteps)
+  }
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -454,7 +454,7 @@ import {
 import { resolveWithin } from '../path'
 import {
   executionOptionsWithProgress,
-  RemoteOrLocalBranchFetchProgressParser,
+  SingleBranchFetchProgressParser,
 } from '../progress'
 import { envForRemoteOperation } from '../git/environment'
 
@@ -6084,17 +6084,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public async _fetchRemoteOrLocalBranch(
+  public async _fetchSingleBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
     return this.withRefreshedGitHubRepository(repository, repo => {
-      return this.performFetchRemoteOrLocalBranch(repo, branch)
+      return this.performFetchSingleBranch(repo, branch)
     })
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  private async performFetchRemoteOrLocalBranch(
+  private async performFetchSingleBranch(
     repository: Repository,
     branch: Branch
   ) {
@@ -6138,7 +6138,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
       opts = await executionOptionsWithProgress(
         { ...opts, trackLFSProgress: true, isBackgroundTask },
-        new RemoteOrLocalBranchFetchProgressParser(),
+        new SingleBranchFetchProgressParser(),
         progress => {
           if (progress.kind === 'context') {
             const text = progress.text

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6088,10 +6088,54 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     branch: Branch
   ) {
-    console.log(repository, ' repository ')
-    console.log(branch, ' branch ')
+    const remoteName = branch.remoteName
+    const remoteBranchName = branch.nameWithoutRemote
 
-    return
+    if (!remoteName) {
+      throw new Error('Remote name not found')
+    }
+
+    // await git(
+    //   ['fetch', remoteName, remoteBranchName],
+    //   repository.path,
+    //   'pullRemoteBranch'
+    // )
+    const backgroundTask = false
+    const gitStore = this.gitStoreCache.get(repository)
+    const remote = { name: remoteName, url: '' }
+    // const progressCallback = (progress: IFetchProgress) => {
+    //   console.log(progress, ' progress ')
+    // }
+
+    const fetchFn = async () => {
+      await git(
+        [
+          'fetch',
+          // ...(progressCallback ? ['--progress'] : []),
+          '--progress',
+          '--prune',
+          '--recurse-submodules=on-demand',
+          remoteName,
+          remoteBranchName,
+        ],
+        repository.path,
+        'pullRemoteBranch'
+      )
+      return true
+    }
+
+    const fetchSucceeded = await gitStore.performFailableOperation(fetchFn, {
+      backgroundTask,
+    })
+
+    if (fetchSucceeded) {
+      await updateRemoteHEAD(repository, remote, backgroundTask).catch(e =>
+        log.error('Failed updating remote HEAD', e)
+      )
+      await this._refreshRepository(repository)
+    } else {
+      console.error('Fetch did not succeed')
+    }
   }
 
   public async _resetHardToUpstream(repository: Repository): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6036,13 +6036,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async withPushPullFetch(
     repository: Repository,
-    fn: () => Promise<void>,
-    onRequestAlreadyInProgress?: () => void
+    fn: () => Promise<void>
   ): Promise<void> {
     const state = this.repositoryStateCache.get(repository)
     // Don't allow concurrent network operations.
     if (state.isPushPullFetchInProgress) {
-      return onRequestAlreadyInProgress?.()
+      return
     }
 
     this.repositoryStateCache.update(repository, () => ({
@@ -6051,10 +6050,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     try {
-      console.log('isPushPullFetchInProgress true')
       await fn()
     } finally {
-      console.log('isPushPullFetchInProgress false')
       this.repositoryStateCache.update(repository, () => ({
         isPushPullFetchInProgress: false,
       }))
@@ -6088,6 +6085,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     branch: Branch
   ): Promise<void> {
+    const state = this.repositoryStateCache.get(repository)
+    // Don't allow concurrent network operations.
+    if (state.isPushPullFetchInProgress) {
+      this._showPopup({
+        type: PopupType.Error,
+        error: new Error(
+          'Another push/pull/fetch request is in progress.\nTry again after the ongoing request is finished'
+        ),
+      })
+      return
+    }
+
     return this.withRefreshedGitHubRepository(repository, repo => {
       return this.performFetchSingleBranch(repo, branch)
     })
@@ -6229,13 +6238,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     try {
-      await this.withPushPullFetch(repository, execFetchFn, () => {
-        this.popupManager.addErrorPopup(
-          new Error(
-            'Another push/pull/fetch request is in progress.\nTry again after the ongoing request is finished'
-          )
-        )
-      })
+      await this.withPushPullFetch(repository, execFetchFn)
     } catch (error) {
       const errorWithMetadata = new ErrorWithMetadata(error, {
         repository,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -265,6 +265,7 @@ import {
   listWorktrees,
   unstageAll,
   git,
+  IGitStringExecutionOptions,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -450,6 +451,8 @@ import {
   gatherCommitContext,
 } from '../copilot-conflict-context'
 import { resolveWithin } from '../path'
+import { executionOptionsWithProgress, FetchProgressParser } from '../progress'
+import { envForRemoteOperation } from '../git/environment'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -6074,20 +6077,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public async _pullRemoteBranch(
+  public async _fetchRemoteBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
     return this.withRefreshedGitHubRepository(repository, repo => {
-      return this.performPullRemoteBranch(repo, branch)
+      return this.performFetchRemoteBranch(repo, branch)
     })
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  private async performPullRemoteBranch(
+  private async performFetchRemoteBranch(
     repository: Repository,
     branch: Branch
   ) {
+    const isRemote = branch.type === BranchType.Remote
+    if (!isRemote) {
+      return
+    }
+
     const remoteName = branch.remoteName
     const remoteBranchName = branch.nameWithoutRemote
 
@@ -6095,23 +6103,68 @@ export class AppStore extends TypedBaseStore<IAppState> {
       throw new Error('Remote name not found')
     }
 
-    // await git(
-    //   ['fetch', remoteName, remoteBranchName],
-    //   repository.path,
-    //   'pullRemoteBranch'
-    // )
-    const backgroundTask = false
+    const isBackgroundTask = false
     const gitStore = this.gitStoreCache.get(repository)
-    const remote = { name: remoteName, url: '' }
-    // const progressCallback = (progress: IFetchProgress) => {
-    //   console.log(progress, ' progress ')
-    // }
+
+    // repository.url
+    const remote = { name: remoteName, url: 'file://' }
+
+    const _fetchRemoteBranchProgressCallback = (progress: any) => {
+      console.log(progress, ' progress ')
+    }
+
+    const title = `Fetching ${remoteName}`
+    const kind = 'fetch'
+    let opts: IGitStringExecutionOptions = {
+      successExitCodes: new Set([0]),
+    }
+    if (remote.url) {
+      opts = {
+        ...opts,
+        env: await envForRemoteOperation(remote.url),
+      }
+    }
+
+    opts = await executionOptionsWithProgress(
+      { ...opts, trackLFSProgress: true, isBackgroundTask },
+      new FetchProgressParser(),
+      progress => {
+        // In addition to progress output from the remote end and from
+        // git itself, the stderr output from pull contains information
+        // about ref updates. We don't need to bring those into the progress
+        // stream so we'll just punt on anything we don't know about for now.
+        if (progress.kind === 'context') {
+          if (!progress.text.startsWith('remote: Counting objects')) {
+            return
+          }
+        }
+
+        const description =
+          progress.kind === 'progress' ? progress.details.text : progress.text
+        const value = progress.percent
+
+        _fetchRemoteBranchProgressCallback({
+          kind,
+          title,
+          description,
+          value,
+          remote: remote.name,
+        })
+      }
+    )
+
+    // Initial progress
+    _fetchRemoteBranchProgressCallback({
+      kind,
+      title,
+      value: 0,
+      remote: remote.name,
+    })
 
     const fetchFn = async () => {
       await git(
         [
           'fetch',
-          // ...(progressCallback ? ['--progress'] : []),
           '--progress',
           '--prune',
           '--recurse-submodules=on-demand',
@@ -6119,19 +6172,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
           remoteBranchName,
         ],
         repository.path,
-        'pullRemoteBranch'
+        'fetchRemoteBranch',
+        opts
       )
       return true
     }
 
     const fetchSucceeded = await gitStore.performFailableOperation(fetchFn, {
-      backgroundTask,
+      backgroundTask: isBackgroundTask,
     })
 
     if (fetchSucceeded) {
-      await updateRemoteHEAD(repository, remote, backgroundTask).catch(e =>
-        log.error('Failed updating remote HEAD', e)
-      )
       await this._refreshRepository(repository)
     } else {
       console.error('Fetch did not succeed')

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6211,30 +6211,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
         value: 0,
         remote: remote.name,
       })
-      try {
-        await gitStore.performFailableOperation(
-          async () => {
-            const result = await fetchFn(isRemote)
-            if (
-              !isRemote &&
-              result &&
-              (result.stderr?.includes('rejected') ||
-                result.stderr?.includes('non-fast-forward'))
-            ) {
-              this.emitError(
-                new ErrorWithMetadata(new Error(result.stderr), { repository })
-              )
-            }
 
-            await this._refreshRepository(repository)
-          },
-          {
-            backgroundTask: isBackgroundTask,
+      await gitStore.performFailableOperation(
+        async () => {
+          const result = await fetchFn(isRemote)
+          if (
+            !isRemote &&
+            result &&
+            (result.stderr?.includes('rejected') ||
+              result.stderr?.includes('non-fast-forward'))
+          ) {
+            this.emitError(
+              new ErrorWithMetadata(new Error(result.stderr), { repository })
+            )
           }
-        )
-      } finally {
-        this.updatePushPullFetchProgress(repository, null)
-      }
+
+          await this._refreshRepository(repository)
+        },
+        {
+          backgroundTask: isBackgroundTask,
+        }
+      )
     }
 
     try {
@@ -6244,6 +6241,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
       })
       this.emitError(errorWithMetadata)
+    } finally {
+      this.updatePushPullFetchProgress(repository, null)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6078,17 +6078,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public async _fetchRemoteBranch(
+  public async _fetchRemoteOrLocalBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
     return this.withRefreshedGitHubRepository(repository, repo => {
-      return this.performFetchRemoteBranch(repo, branch)
+      return this.performFetchRemoteOrLocalBranch(repo, branch)
     })
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  private async performFetchRemoteBranch(
+  private async performFetchRemoteOrLocalBranch(
     repository: Repository,
     branch: Branch
   ) {
@@ -6112,7 +6112,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // repository.url
     const remote = { name: remoteName, url: 'file://' }
 
-    const _fetchRemoteBranchProgressCallback = (progress: any) => {
+    const progressCb = (progress: any) => {
       console.log(progress, ' progress ')
     }
 
@@ -6136,6 +6136,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // git itself, the stderr output from pull contains information
         // about ref updates. We don't need to bring those into the progress
         // stream so we'll just punt on anything we don't know about for now.
+        console.log(progress, ' progress ')
         if (progress.kind === 'context') {
           if (!progress.text.startsWith('remote: Counting objects')) {
             return
@@ -6146,7 +6147,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           progress.kind === 'progress' ? progress.details.text : progress.text
         const value = progress.percent
 
-        _fetchRemoteBranchProgressCallback({
+        progressCb({
           kind,
           title,
           description,
@@ -6157,7 +6158,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
 
     // Initial progress
-    _fetchRemoteBranchProgressCallback({
+    progressCb({
       kind,
       title,
       value: 0,
@@ -6200,7 +6201,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     }
 
-    try {
+    const execFetchFn = async () => {
       await gitStore.performFailableOperation(
         async () => {
           const result = await fetchFn(isRemote, opts)
@@ -6210,20 +6211,26 @@ export class AppStore extends TypedBaseStore<IAppState> {
             (result.stderr?.includes('rejected') ||
               result.stderr?.includes('non-fast-forward'))
           ) {
-            console.error(
-              `[UI/ERROR] Merge conflict/Divergence detected on ${remoteBranchName}.`
+            this.emitError(
+              new ErrorWithMetadata(new Error(result.stderr), { repository })
             )
-
-            this.popupManager.addErrorPopup(new Error(result.stderr))
           }
 
           await this._refreshRepository(repository)
-          console.log(`[UI] Success! ${remoteBranchName} updated cleanly.`)
         },
         {
           backgroundTask: isBackgroundTask,
         }
       )
+    }
+
+    try {
+      await this.withPushPullFetch(repository, execFetchFn)
+    } catch (error) {
+      const errorWithMetadata = new ErrorWithMetadata(error, {
+        repository,
+      })
+      this.emitError(errorWithMetadata)
     } finally {
       console.log(`[UI] Stopping spinner for ${remoteBranchName}.`)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6074,6 +6074,26 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
+  public async _pullRemoteBranch(
+    repository: Repository,
+    branch: Branch
+  ): Promise<void> {
+    return this.withRefreshedGitHubRepository(repository, repo => {
+      return this.performPullRemoteBranch(repo, branch)
+    })
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  private async performPullRemoteBranch(
+    repository: Repository,
+    branch: Branch
+  ) {
+    console.log(repository, ' repository ')
+    console.log(branch, ' branch ')
+
+    return
+  }
+
   public async _resetHardToUpstream(repository: Repository): Promise<void> {
     const { branchesState } = this.repositoryStateCache.get(repository)
     const { tip } = branchesState

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6112,11 +6112,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // repository.url
     const remote = { name: remoteName, url: 'file://' }
 
-    const progressCb = (progress: any) => {
-      console.log(progress, ' progress ')
+    const progressCb = (progress: IFetchProgress) => {
+      this.updatePushPullFetchProgress(repository, progress)
     }
 
-    const title = `Fetching ${remoteName}`
+    const progressTitle = isRemote
+      ? `Fetching ${branch.name}`
+      : `Fetching ${remoteBranchName}`
     const kind = 'fetch'
     let opts: IGitStringExecutionOptions = {
       successExitCodes: new Set([0]),
@@ -6132,11 +6134,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       { ...opts, trackLFSProgress: true, isBackgroundTask },
       new FetchProgressParser(),
       progress => {
+        console.log(progress, ' progress_log ')
         // In addition to progress output from the remote end and from
         // git itself, the stderr output from pull contains information
         // about ref updates. We don't need to bring those into the progress
         // stream so we'll just punt on anything we don't know about for now.
-        console.log(progress, ' progress ')
         if (progress.kind === 'context') {
           if (!progress.text.startsWith('remote: Counting objects')) {
             return
@@ -6149,22 +6151,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
         progressCb({
           kind,
-          title,
+          title: progressTitle,
           description,
           value,
           remote: remote.name,
         })
       }
     )
-
-    // Initial progress
-    progressCb({
-      kind,
-      title,
-      value: 0,
-      remote: remote.name,
-    })
-    console.log(`[UI] Starting background update for: ${remoteBranchName}...`)
 
     const fetchFn = async (
       isRemote: boolean,
@@ -6202,6 +6195,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const execFetchFn = async () => {
+      // Initial progress
+      progressCb({
+        kind,
+        title: progressTitle,
+        value: 0,
+        remote: remote.name,
+      })
       await gitStore.performFailableOperation(
         async () => {
           const result = await fetchFn(isRemote, opts)
@@ -6232,7 +6232,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
       this.emitError(errorWithMetadata)
     } finally {
-      console.log(`[UI] Stopping spinner for ${remoteBranchName}.`)
+      this.updatePushPullFetchProgress(repository, null)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -452,7 +452,10 @@ import {
   gatherCommitContext,
 } from '../copilot-conflict-context'
 import { resolveWithin } from '../path'
-import { executionOptionsWithProgress, FetchProgressParser } from '../progress'
+import {
+  executionOptionsWithProgress,
+  RemoteOrLocalBranchFetchProgressParser,
+} from '../progress'
 import { envForRemoteOperation } from '../git/environment'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
@@ -6033,12 +6036,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async withPushPullFetch(
     repository: Repository,
-    fn: () => Promise<void>
+    fn: () => Promise<void>,
+    onRequestAlreadyInProgress?: () => void
   ): Promise<void> {
     const state = this.repositoryStateCache.get(repository)
     // Don't allow concurrent network operations.
     if (state.isPushPullFetchInProgress) {
-      return
+      return onRequestAlreadyInProgress?.()
     }
 
     this.repositoryStateCache.update(repository, () => ({
@@ -6047,8 +6051,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     try {
+      console.log('isPushPullFetchInProgress true')
       await fn()
     } finally {
+      console.log('isPushPullFetchInProgress false')
       this.repositoryStateCache.update(repository, () => ({
         isPushPullFetchInProgress: false,
       }))
@@ -6115,60 +6121,54 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const progressCb = (progress: IFetchProgress) => {
       this.updatePushPullFetchProgress(repository, progress)
     }
-
     const progressTitle = isRemote
       ? `Fetching ${branch.name}`
       : `Fetching ${remoteBranchName}`
     const kind = 'fetch'
-    let opts: IGitStringExecutionOptions = {
-      successExitCodes: new Set([0]),
-    }
-    if (remote.url) {
-      opts = {
-        ...opts,
-        env: await envForRemoteOperation(remote.url),
-      }
-    }
 
-    opts = await executionOptionsWithProgress(
-      { ...opts, trackLFSProgress: true, isBackgroundTask },
-      new FetchProgressParser(),
-      progress => {
-        console.log(progress, ' progress_log ')
-        // In addition to progress output from the remote end and from
-        // git itself, the stderr output from pull contains information
-        // about ref updates. We don't need to bring those into the progress
-        // stream so we'll just punt on anything we don't know about for now.
-        if (progress.kind === 'context') {
-          if (!progress.text.startsWith('remote: Counting objects')) {
-            return
-          }
+    const fetchFn = async (isRemote: boolean): Promise<IGitStringResult> => {
+      let opts: IGitStringExecutionOptions = {
+        successExitCodes: new Set([0]),
+      }
+      if (remote.url) {
+        opts = {
+          ...opts,
+          env: await envForRemoteOperation(remote.url),
         }
-
-        const description =
-          progress.kind === 'progress' ? progress.details.text : progress.text
-        const value = progress.percent
-
-        progressCb({
-          kind,
-          title: progressTitle,
-          description,
-          value,
-          remote: remote.name,
-        })
       }
-    )
+      opts = await executionOptionsWithProgress(
+        { ...opts, trackLFSProgress: true, isBackgroundTask },
+        new RemoteOrLocalBranchFetchProgressParser(),
+        progress => {
+          if (progress.kind === 'context') {
+            const text = progress.text
+            if (
+              !text.startsWith('remote: Counting objects') &&
+              !text.startsWith('remote: Compressing objects')
+            ) {
+              return
+            }
+          }
 
-    const fetchFn = async (
-      isRemote: boolean,
-      opts: IGitStringExecutionOptions = {}
-    ): Promise<IGitStringResult> => {
+          const description =
+            progress.kind === 'progress' ? progress.details.text : progress.text
+          const value = progress.percent
+
+          progressCb({
+            kind,
+            title: progressTitle,
+            description,
+            value,
+            remote: remote.name,
+          })
+        }
+      )
       const flags = isRemote
         ? ['fetch', '--progress', '--recurse-submodules=on-demand', remoteName]
         : [
             'fetch',
             '--progress',
-            // '--show-forced-updates',
+            '--show-forced-updates',
             // '--no-write-fetch-head',
             '--recurse-submodules=on-demand',
             remoteName,
@@ -6202,37 +6202,45 @@ export class AppStore extends TypedBaseStore<IAppState> {
         value: 0,
         remote: remote.name,
       })
-      await gitStore.performFailableOperation(
-        async () => {
-          const result = await fetchFn(isRemote, opts)
-          if (
-            !isRemote &&
-            result &&
-            (result.stderr?.includes('rejected') ||
-              result.stderr?.includes('non-fast-forward'))
-          ) {
-            this.emitError(
-              new ErrorWithMetadata(new Error(result.stderr), { repository })
-            )
-          }
+      try {
+        await gitStore.performFailableOperation(
+          async () => {
+            const result = await fetchFn(isRemote)
+            if (
+              !isRemote &&
+              result &&
+              (result.stderr?.includes('rejected') ||
+                result.stderr?.includes('non-fast-forward'))
+            ) {
+              this.emitError(
+                new ErrorWithMetadata(new Error(result.stderr), { repository })
+              )
+            }
 
-          await this._refreshRepository(repository)
-        },
-        {
-          backgroundTask: isBackgroundTask,
-        }
-      )
+            await this._refreshRepository(repository)
+          },
+          {
+            backgroundTask: isBackgroundTask,
+          }
+        )
+      } finally {
+        this.updatePushPullFetchProgress(repository, null)
+      }
     }
 
     try {
-      await this.withPushPullFetch(repository, execFetchFn)
+      await this.withPushPullFetch(repository, execFetchFn, () => {
+        this.popupManager.addErrorPopup(
+          new Error(
+            'Another push/pull/fetch request is in progress.\nTry again after the ongoing request is finished'
+          )
+        )
+      })
     } catch (error) {
       const errorWithMetadata = new ErrorWithMetadata(error, {
         repository,
       })
       this.emitError(errorWithMetadata)
-    } finally {
-      this.updatePushPullFetchProgress(repository, null)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -266,6 +266,7 @@ import {
   unstageAll,
   git,
   IGitStringExecutionOptions,
+  IGitStringResult,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -6092,15 +6093,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: Branch
   ) {
     const isRemote = branch.type === BranchType.Remote
-    if (!isRemote) {
-      return
-    }
 
-    const remoteName = branch.remoteName
-    const remoteBranchName = branch.nameWithoutRemote
+    const remoteName = isRemote ? branch.remoteName : branch.upstreamRemoteName
+    const remoteBranchName = isRemote
+      ? branch.nameWithoutRemote
+      : branch.upstreamWithoutRemote
 
     if (!remoteName) {
       throw new Error('Remote name not found')
+    }
+    if (!remoteBranchName) {
+      throw new Error('Remote branch not found')
     }
 
     const isBackgroundTask = false
@@ -6160,32 +6163,69 @@ export class AppStore extends TypedBaseStore<IAppState> {
       value: 0,
       remote: remote.name,
     })
+    console.log(`[UI] Starting background update for: ${remoteBranchName}...`)
 
-    const fetchFn = async () => {
-      await git(
-        [
-          'fetch',
-          '--progress',
-          '--prune',
-          '--recurse-submodules=on-demand',
-          remoteName,
-          remoteBranchName,
-        ],
+    const fetchFn = async (
+      isRemote: boolean,
+      opts: IGitStringExecutionOptions = {}
+    ): Promise<IGitStringResult> => {
+      const flags = isRemote
+        ? ['fetch', '--progress', '--recurse-submodules=on-demand', remoteName]
+        : [
+            'fetch',
+            '--progress',
+            // '--show-forced-updates',
+            // '--no-write-fetch-head',
+            '--recurse-submodules=on-demand',
+            remoteName,
+          ]
+
+      const branchTarget = isRemote
+        ? remoteBranchName
+        : `${remoteBranchName}:${remoteBranchName}`
+      const actionName = isRemote ? 'fetchRemoteBranch' : 'fetchLocalBranch'
+
+      const executionOpts = isRemote
+        ? opts
+        : {
+            ...opts,
+            successExitCodes: new Set([0, 1]),
+          }
+
+      return await git(
+        [...flags, branchTarget],
         repository.path,
-        'fetchRemoteBranch',
-        opts
+        actionName,
+        executionOpts
       )
-      return true
     }
 
-    const fetchSucceeded = await gitStore.performFailableOperation(fetchFn, {
-      backgroundTask: isBackgroundTask,
-    })
+    try {
+      await gitStore.performFailableOperation(
+        async () => {
+          const result = await fetchFn(isRemote, opts)
+          if (
+            !isRemote &&
+            result &&
+            (result.stderr?.includes('rejected') ||
+              result.stderr?.includes('non-fast-forward'))
+          ) {
+            console.error(
+              `[UI/ERROR] Merge conflict/Divergence detected on ${remoteBranchName}.`
+            )
 
-    if (fetchSucceeded) {
-      await this._refreshRepository(repository)
-    } else {
-      console.error('Fetch did not succeed')
+            this.popupManager.addErrorPopup(new Error(result.stderr))
+          }
+
+          await this._refreshRepository(repository)
+          console.log(`[UI] Success! ${remoteBranchName} updated cleanly.`)
+        },
+        {
+          backgroundTask: isBackgroundTask,
+        }
+      )
+    } finally {
+      console.log(`[UI] Stopping spinner for ${remoteBranchName}.`)
     }
   }
 

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -14,6 +14,7 @@ interface IBranchContextMenuConfig {
   onViewPullRequestOnGitHub?: () => void
   onSetAsDefaultBranch?: (branchName: string) => void
   onDeleteBranch?: (branchName: string) => void
+  onPullRemoteBranch?: (branchName: string) => void
 }
 
 export function generateBranchContextMenuItems(
@@ -30,6 +31,7 @@ export function generateBranchContextMenuItems(
     onViewPullRequestOnGitHub,
     onSetAsDefaultBranch,
     onDeleteBranch,
+    onPullRemoteBranch,
   } = config
   const items = new Array<IMenuItem>()
 
@@ -38,6 +40,14 @@ export function generateBranchContextMenuItems(
       label: 'Rename…',
       action: () => onRenameBranch(name),
       enabled: isLocal,
+    })
+  }
+
+  if (onPullRemoteBranch !== undefined) {
+    items.push({
+      label: getRemotePullBranchLabel(),
+      action: () => onPullRemoteBranch(name),
+      enabled: true,
     })
   }
 
@@ -103,4 +113,18 @@ function getViewPullRequestLabel(repoType: RepoType): string {
     default:
       return assertNever(repoType, `Unknown repo type: ${repoType}`)
   }
+}
+
+function getRemotePullBranchLabel(): string {
+  return 'Pull branch'
+  // switch (repoType) {
+  //   case 'github':
+  //     return 'Pull branch from Github'
+  //   case 'bitbucket':
+  //     return 'Pull branch from Bitbucket'
+  //   case 'gitlab':
+  //     return 'Pull branch from GitLab'
+  //   default:
+  //     return assertNever(repoType, `Unknown repo type: ${repoType}`)
+  // }
 }

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -6,7 +6,6 @@ import { assertNever } from '../../lib/fatal-error'
 interface IBranchContextMenuConfig {
   name: string
   nameWithoutRemote: string
-  isDefault: boolean
   isLocal: boolean
   isCurrentBranch: boolean
   repoType: RepoType | undefined
@@ -16,7 +15,7 @@ interface IBranchContextMenuConfig {
   onViewPullRequestOnGitHub?: () => void
   onSetAsDefaultBranch?: (branchName: string) => void
   onDeleteBranch?: (branchName: string) => void
-  onFetchRemoteBranch?: (branchName: string) => void
+  onFetchRemoteOrLocalBranch?: (branchName: string) => void
 }
 
 export function generateBranchContextMenuItems(
@@ -26,7 +25,6 @@ export function generateBranchContextMenuItems(
     name,
     nameWithoutRemote,
     isLocal,
-    isDefault,
     isCurrentBranch,
     repoType,
     isInUseByOtherWorktree,
@@ -35,7 +33,7 @@ export function generateBranchContextMenuItems(
     onViewPullRequestOnGitHub,
     onSetAsDefaultBranch,
     onDeleteBranch,
-    onFetchRemoteBranch,
+    onFetchRemoteOrLocalBranch,
   } = config
   const items = new Array<IMenuItem>()
   if (onRenameBranch !== undefined) {
@@ -73,11 +71,11 @@ export function generateBranchContextMenuItems(
   }
 
   // This should be the selected branch.
-  if (!isDefault && !isCurrentBranch && onFetchRemoteBranch !== undefined) {
+  if (!isCurrentBranch && onFetchRemoteOrLocalBranch !== undefined) {
     items.push({ type: 'separator' })
     items.push({
       label: getRemoteFetchBranchLabel(),
-      action: () => onFetchRemoteBranch(name),
+      action: () => onFetchRemoteOrLocalBranch(name),
       enabled: true,
     })
   }

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -5,6 +5,7 @@ import { assertNever } from '../../lib/fatal-error'
 
 interface IBranchContextMenuConfig {
   name: string
+  remoteName?: string | null
   nameWithoutRemote: string
   isLocal: boolean
   repoType: RepoType | undefined
@@ -14,7 +15,7 @@ interface IBranchContextMenuConfig {
   onViewPullRequestOnGitHub?: () => void
   onSetAsDefaultBranch?: (branchName: string) => void
   onDeleteBranch?: (branchName: string) => void
-  onPullRemoteBranch?: (branchName: string) => void
+  onFetchRemoteBranch?: (branchName: string) => void
 }
 
 export function generateBranchContextMenuItems(
@@ -23,6 +24,7 @@ export function generateBranchContextMenuItems(
   const {
     name,
     nameWithoutRemote,
+    remoteName,
     isLocal,
     repoType,
     isInUseByOtherWorktree,
@@ -31,7 +33,7 @@ export function generateBranchContextMenuItems(
     onViewPullRequestOnGitHub,
     onSetAsDefaultBranch,
     onDeleteBranch,
-    onPullRemoteBranch,
+    onFetchRemoteBranch,
   } = config
   const items = new Array<IMenuItem>()
 
@@ -43,11 +45,11 @@ export function generateBranchContextMenuItems(
     })
   }
 
-  if (onPullRemoteBranch !== undefined && !isLocal) {
+  if (!isLocal && onFetchRemoteBranch !== undefined) {
     items.push({
-      label: getRemotePullBranchLabel(),
-      action: () => onPullRemoteBranch(name),
-      enabled: true,
+      label: getRemoteFetchBranchLabel(),
+      action: () => onFetchRemoteBranch(name),
+      enabled: !!remoteName,
     })
   }
 
@@ -115,16 +117,6 @@ function getViewPullRequestLabel(repoType: RepoType): string {
   }
 }
 
-function getRemotePullBranchLabel(): string {
-  return 'Pull branch'
-  // switch (repoType) {
-  //   case 'github':
-  //     return 'Pull branch from Github'
-  //   case 'bitbucket':
-  //     return 'Pull branch from Bitbucket'
-  //   case 'gitlab':
-  //     return 'Pull branch from GitLab'
-  //   default:
-  //     return assertNever(repoType, `Unknown repo type: ${repoType}`)
-  // }
+function getRemoteFetchBranchLabel(): string {
+  return `Fetch branch`
 }

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -43,7 +43,7 @@ export function generateBranchContextMenuItems(
     })
   }
 
-  if (onPullRemoteBranch !== undefined) {
+  if (onPullRemoteBranch !== undefined && !isLocal) {
     items.push({
       label: getRemotePullBranchLabel(),
       action: () => onPullRemoteBranch(name),

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -15,7 +15,7 @@ interface IBranchContextMenuConfig {
   onViewPullRequestOnGitHub?: () => void
   onSetAsDefaultBranch?: (branchName: string) => void
   onDeleteBranch?: (branchName: string) => void
-  onFetchRemoteOrLocalBranch?: (branchName: string) => void
+  onFetchSingleBranch?: (branchName: string) => void
 }
 
 export function generateBranchContextMenuItems(
@@ -33,7 +33,7 @@ export function generateBranchContextMenuItems(
     onViewPullRequestOnGitHub,
     onSetAsDefaultBranch,
     onDeleteBranch,
-    onFetchRemoteOrLocalBranch,
+    onFetchSingleBranch,
   } = config
   const items = new Array<IMenuItem>()
   if (onRenameBranch !== undefined) {
@@ -71,11 +71,11 @@ export function generateBranchContextMenuItems(
   }
 
   // This should be the selected branch.
-  if (!isCurrentBranch && onFetchRemoteOrLocalBranch !== undefined) {
+  if (!isCurrentBranch && onFetchSingleBranch !== undefined) {
     items.push({ type: 'separator' })
     items.push({
-      label: getRemoteFetchBranchLabel(),
-      action: () => onFetchRemoteOrLocalBranch(name),
+      label: getSingleFetchBranchLabel(),
+      action: () => onFetchSingleBranch(name),
       enabled: true,
     })
   }
@@ -118,6 +118,6 @@ function getViewPullRequestLabel(repoType: RepoType): string {
   }
 }
 
-function getRemoteFetchBranchLabel(): string {
+function getSingleFetchBranchLabel(): string {
   return __DARWIN__ ? 'Fetch Branch' : 'Fetch branch'
 }

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -5,9 +5,10 @@ import { assertNever } from '../../lib/fatal-error'
 
 interface IBranchContextMenuConfig {
   name: string
-  remoteName?: string | null
   nameWithoutRemote: string
+  isDefault: boolean
   isLocal: boolean
+  isCurrentBranch: boolean
   repoType: RepoType | undefined
   isInUseByOtherWorktree: boolean
   onRenameBranch?: (branchName: string) => void
@@ -24,8 +25,9 @@ export function generateBranchContextMenuItems(
   const {
     name,
     nameWithoutRemote,
-    remoteName,
     isLocal,
+    isDefault,
+    isCurrentBranch,
     repoType,
     isInUseByOtherWorktree,
     onRenameBranch,
@@ -36,20 +38,11 @@ export function generateBranchContextMenuItems(
     onFetchRemoteBranch,
   } = config
   const items = new Array<IMenuItem>()
-
   if (onRenameBranch !== undefined) {
     items.push({
       label: 'Rename…',
       action: () => onRenameBranch(name),
       enabled: isLocal,
-    })
-  }
-
-  if (!isLocal && onFetchRemoteBranch !== undefined) {
-    items.push({
-      label: getRemoteFetchBranchLabel(),
-      action: () => onFetchRemoteBranch(name),
-      enabled: !!remoteName,
     })
   }
 
@@ -76,6 +69,16 @@ export function generateBranchContextMenuItems(
     items.push({
       label: __DARWIN__ ? 'Set as Default Branch' : 'Set as default branch',
       action: () => onSetAsDefaultBranch(nameWithoutRemote),
+    })
+  }
+
+  // This should be the selected branch.
+  if (!isDefault && !isCurrentBranch && onFetchRemoteBranch !== undefined) {
+    items.push({ type: 'separator' })
+    items.push({
+      label: getRemoteFetchBranchLabel(),
+      action: () => onFetchRemoteBranch(name),
+      enabled: true,
     })
   }
 
@@ -118,5 +121,5 @@ function getViewPullRequestLabel(repoType: RepoType): string {
 }
 
 function getRemoteFetchBranchLabel(): string {
-  return `Fetch branch`
+  return __DARWIN__ ? 'Fetch Branch' : 'Fetch branch'
 }

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -146,7 +146,7 @@ interface IBranchListProps {
   readonly onDeleteBranch?: (branchName: string) => void
 
   /** Optional: Callback if pull option for remote branch context menu should exist */
-  readonly onFetchRemoteOrLocalBranch?: (branchName: string) => void
+  readonly onFetchSingleBranch?: (branchName: string) => void
 }
 
 /** The Branches list component. */
@@ -241,7 +241,7 @@ export class BranchList extends React.Component<IBranchListProps> {
       onRenameBranch,
       onDeleteBranch,
       onSetAsDefaultBranch,
-      onFetchRemoteOrLocalBranch,
+      onFetchSingleBranch,
     } = this.props
 
     if (
@@ -268,7 +268,7 @@ export class BranchList extends React.Component<IBranchListProps> {
           ? undefined
           : onSetAsDefaultBranch,
       onDeleteBranch,
-      onFetchRemoteOrLocalBranch,
+      onFetchSingleBranch,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -146,7 +146,7 @@ interface IBranchListProps {
   readonly onDeleteBranch?: (branchName: string) => void
 
   /** Optional: Callback if pull option for remote branch context menu should exist */
-  readonly onPullRemoteBranch?: (branchName: string) => void
+  readonly onFetchRemoteBranch?: (branchName: string) => void
 }
 
 /** The Branches list component. */
@@ -241,7 +241,7 @@ export class BranchList extends React.Component<IBranchListProps> {
       onRenameBranch,
       onDeleteBranch,
       onSetAsDefaultBranch,
-      onPullRemoteBranch,
+      onFetchRemoteBranch,
     } = this.props
 
     if (
@@ -252,12 +252,13 @@ export class BranchList extends React.Component<IBranchListProps> {
       return
     }
 
-    const { type, name, nameWithoutRemote } = item.branch
+    const { type, name, nameWithoutRemote, remoteName } = item.branch
     const isLocal = type === BranchType.Local
     const isInUseByOtherWorktree = !!this.inUseByOtherWorktreeName(item)
 
     const items = generateBranchContextMenuItems({
       name,
+      remoteName,
       nameWithoutRemote,
       isLocal,
       repoType: this.props.repository.gitHubRepository?.type,
@@ -268,7 +269,7 @@ export class BranchList extends React.Component<IBranchListProps> {
           ? undefined
           : onSetAsDefaultBranch,
       onDeleteBranch,
-      onPullRemoteBranch,
+      onFetchRemoteBranch,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -255,12 +255,13 @@ export class BranchList extends React.Component<IBranchListProps> {
     const { type, name, nameWithoutRemote, remoteName } = item.branch
     const isLocal = type === BranchType.Local
     const isInUseByOtherWorktree = !!this.inUseByOtherWorktreeName(item)
-
+    const isDefault = nameWithoutRemote === this.props.repository.defaultBranch
     const items = generateBranchContextMenuItems({
       name,
       remoteName,
       nameWithoutRemote,
       isLocal,
+      isDefault,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree,
       onRenameBranch,

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -146,7 +146,7 @@ interface IBranchListProps {
   readonly onDeleteBranch?: (branchName: string) => void
 
   /** Optional: Callback if pull option for remote branch context menu should exist */
-  readonly onFetchRemoteBranch?: (branchName: string) => void
+  readonly onFetchRemoteOrLocalBranch?: (branchName: string) => void
 }
 
 /** The Branches list component. */
@@ -241,7 +241,7 @@ export class BranchList extends React.Component<IBranchListProps> {
       onRenameBranch,
       onDeleteBranch,
       onSetAsDefaultBranch,
-      onFetchRemoteBranch,
+      onFetchRemoteOrLocalBranch,
     } = this.props
 
     if (
@@ -255,12 +255,10 @@ export class BranchList extends React.Component<IBranchListProps> {
     const { type, name, nameWithoutRemote } = item.branch
     const isLocal = type === BranchType.Local
     const isInUseByOtherWorktree = !!this.inUseByOtherWorktreeName(item)
-    const isDefault = nameWithoutRemote === this.props.repository.defaultBranch
     const items = generateBranchContextMenuItems({
       name,
       nameWithoutRemote,
       isLocal,
-      isDefault,
       isCurrentBranch: item.branch.name === this.props.currentBranch?.name,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree,
@@ -270,7 +268,7 @@ export class BranchList extends React.Component<IBranchListProps> {
           ? undefined
           : onSetAsDefaultBranch,
       onDeleteBranch,
-      onFetchRemoteBranch,
+      onFetchRemoteOrLocalBranch,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -144,6 +144,9 @@ interface IBranchListProps {
 
   /** Optional: Callback for if delete context menu should exist */
   readonly onDeleteBranch?: (branchName: string) => void
+
+  /** Optional: Callback if pull option for remote branch context menu should exist */
+  readonly onPullRemoteBranch?: (branchName: string) => void
 }
 
 /** The Branches list component. */
@@ -234,7 +237,12 @@ export class BranchList extends React.Component<IBranchListProps> {
   ) => {
     event.preventDefault()
 
-    const { onRenameBranch, onDeleteBranch, onSetAsDefaultBranch } = this.props
+    const {
+      onRenameBranch,
+      onDeleteBranch,
+      onSetAsDefaultBranch,
+      onPullRemoteBranch,
+    } = this.props
 
     if (
       onRenameBranch === undefined &&
@@ -260,6 +268,7 @@ export class BranchList extends React.Component<IBranchListProps> {
           ? undefined
           : onSetAsDefaultBranch,
       onDeleteBranch,
+      onPullRemoteBranch,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -252,16 +252,16 @@ export class BranchList extends React.Component<IBranchListProps> {
       return
     }
 
-    const { type, name, nameWithoutRemote, remoteName } = item.branch
+    const { type, name, nameWithoutRemote } = item.branch
     const isLocal = type === BranchType.Local
     const isInUseByOtherWorktree = !!this.inUseByOtherWorktreeName(item)
     const isDefault = nameWithoutRemote === this.props.repository.defaultBranch
     const items = generateBranchContextMenuItems({
       name,
-      remoteName,
       nameWithoutRemote,
       isLocal,
       isDefault,
+      isCurrentBranch: item.branch.name === this.props.currentBranch?.name,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree,
       onRenameBranch,

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -53,7 +53,7 @@ interface IBranchesContainerProps {
   readonly onRenameBranch: (branchName: string) => void
   readonly onSetAsDefaultBranch: (branchName: string) => void
   readonly onDeleteBranch: (branchName: string) => void
-  readonly onPullRemoteBranch: (branchName: string) => void
+  readonly onFetchRemoteBranch: (branchName: string) => void
 
   readonly branchSortOrder: BranchSortOrder
 
@@ -294,7 +294,7 @@ export class BranchesContainer extends React.Component<
             onRenameBranch={this.props.onRenameBranch}
             onSetAsDefaultBranch={this.props.onSetAsDefaultBranch}
             onDeleteBranch={this.props.onDeleteBranch}
-            onPullRemoteBranch={this.props.onPullRemoteBranch}
+            onFetchRemoteBranch={this.props.onFetchRemoteBranch}
           />
         )
       case BranchesTab.PullRequests: {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -53,7 +53,7 @@ interface IBranchesContainerProps {
   readonly onRenameBranch: (branchName: string) => void
   readonly onSetAsDefaultBranch: (branchName: string) => void
   readonly onDeleteBranch: (branchName: string) => void
-  readonly onFetchRemoteBranch: (branchName: string) => void
+  readonly onFetchRemoteOrLocalBranch: (branchName: string) => void
 
   readonly branchSortOrder: BranchSortOrder
 
@@ -294,7 +294,7 @@ export class BranchesContainer extends React.Component<
             onRenameBranch={this.props.onRenameBranch}
             onSetAsDefaultBranch={this.props.onSetAsDefaultBranch}
             onDeleteBranch={this.props.onDeleteBranch}
-            onFetchRemoteBranch={this.props.onFetchRemoteBranch}
+            onFetchRemoteOrLocalBranch={this.props.onFetchRemoteOrLocalBranch}
           />
         )
       case BranchesTab.PullRequests: {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -53,7 +53,7 @@ interface IBranchesContainerProps {
   readonly onRenameBranch: (branchName: string) => void
   readonly onSetAsDefaultBranch: (branchName: string) => void
   readonly onDeleteBranch: (branchName: string) => void
-  readonly onFetchRemoteOrLocalBranch: (branchName: string) => void
+  readonly onFetchSingleBranch: (branchName: string) => void
 
   readonly branchSortOrder: BranchSortOrder
 
@@ -294,7 +294,7 @@ export class BranchesContainer extends React.Component<
             onRenameBranch={this.props.onRenameBranch}
             onSetAsDefaultBranch={this.props.onSetAsDefaultBranch}
             onDeleteBranch={this.props.onDeleteBranch}
-            onFetchRemoteOrLocalBranch={this.props.onFetchRemoteOrLocalBranch}
+            onFetchSingleBranch={this.props.onFetchSingleBranch}
           />
         )
       case BranchesTab.PullRequests: {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -53,6 +53,7 @@ interface IBranchesContainerProps {
   readonly onRenameBranch: (branchName: string) => void
   readonly onSetAsDefaultBranch: (branchName: string) => void
   readonly onDeleteBranch: (branchName: string) => void
+  readonly onPullRemoteBranch: (branchName: string) => void
 
   readonly branchSortOrder: BranchSortOrder
 
@@ -293,6 +294,7 @@ export class BranchesContainer extends React.Component<
             onRenameBranch={this.props.onRenameBranch}
             onSetAsDefaultBranch={this.props.onSetAsDefaultBranch}
             onDeleteBranch={this.props.onDeleteBranch}
+            onPullRemoteBranch={this.props.onPullRemoteBranch}
           />
         )
       case BranchesTab.PullRequests: {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -822,11 +822,11 @@ export class Dispatcher {
   }
 
   /** Pull remote branch by name */
-  public fetchRemoteOrLocalBranch(
+  public fetchSingleBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
-    return this.appStore._fetchRemoteOrLocalBranch(repository, branch)
+    return this.appStore._fetchSingleBranch(repository, branch)
   }
 
   public async pullAllRepositories(): Promise<void> {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -821,6 +821,14 @@ export class Dispatcher {
     return this.appStore._pull(repository)
   }
 
+  /** Pull remote branch by name */
+  public pullRemoteBranch(
+    repository: Repository,
+    branch: Branch
+  ): Promise<void> {
+    return this.appStore._pullRemoteBranch(repository, branch)
+  }
+
   public async pullAllRepositories(): Promise<void> {
     try {
       await this.appStore._pullAllRepositories()

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -822,11 +822,11 @@ export class Dispatcher {
   }
 
   /** Pull remote branch by name */
-  public pullRemoteBranch(
+  public fetchRemoteBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
-    return this.appStore._pullRemoteBranch(repository, branch)
+    return this.appStore._fetchRemoteBranch(repository, branch)
   }
 
   public async pullAllRepositories(): Promise<void> {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -822,11 +822,11 @@ export class Dispatcher {
   }
 
   /** Pull remote branch by name */
-  public fetchRemoteBranch(
+  public fetchRemoteOrLocalBranch(
     repository: Repository,
     branch: Branch
   ): Promise<void> {
-    return this.appStore._fetchRemoteBranch(repository, branch)
+    return this.appStore._fetchRemoteOrLocalBranch(repository, branch)
   }
 
   public async pullAllRepositories(): Promise<void> {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -317,10 +317,12 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     }
 
     const { name, type, nameWithoutRemote } = tip.branch
+    const isDefault = nameWithoutRemote === this.props.repository.defaultBranch
     const items = generateBranchContextMenuItems({
       name,
       nameWithoutRemote,
       isLocal: type === BranchType.Local,
+      isDefault,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree: false,
       onRenameBranch: this.onRenameBranch,
@@ -332,10 +334,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       onViewPullRequestOnGitHub: this.props.currentPullRequest
         ? this.onViewPullRequestOnGithub
         : undefined,
-      onSetAsDefaultBranch:
-        nameWithoutRemote === this.props.repository.defaultBranch
-          ? undefined
-          : this.onSetAsDefaultBranch,
+      onSetAsDefaultBranch: isDefault ? undefined : this.onSetAsDefaultBranch,
       onDeleteBranch: this.onDeleteBranch,
     })
 
@@ -453,9 +452,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     }
 
     // Only fetch remote branch
-    if (branch.type === BranchType.Remote) {
-      dispatcher.fetchRemoteBranch(repository, branch)
-    }
+    // if (branch.type === BranchType.Remote) {
+    // }
+    dispatcher.fetchRemoteBranch(repository, branch)
   }
 
   private onBadgeClick = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -118,7 +118,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         branchSortOrder={this.props.branchSortOrder}
         emoji={this.props.emoji}
         onDeleteBranch={this.onDeleteBranch}
-        onFetchRemoteOrLocalBranch={this.onFetchRemoteOrLocalBranch}
+        onFetchSingleBranch={this.onFetchSingleBranch}
         onRenameBranch={this.onRenameBranch}
         onSetAsDefaultBranch={this.onSetAsDefaultBranch}
         underlineLinks={this.props.underlineLinks}
@@ -445,16 +445,13 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     })
   }
 
-  private onFetchRemoteOrLocalBranch = (branchName: string) => {
+  private onFetchSingleBranch = (branchName: string) => {
     const branch = this.getBranchWithName(branchName)
     if (!branch) {
       return
     }
 
-    this.props.dispatcher.fetchRemoteOrLocalBranch(
-      this.props.repository,
-      branch
-    )
+    this.props.dispatcher.fetchSingleBranch(this.props.repository, branch)
   }
 
   private onBadgeClick = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -118,6 +118,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         branchSortOrder={this.props.branchSortOrder}
         emoji={this.props.emoji}
         onDeleteBranch={this.onDeleteBranch}
+        onPullRemoteBranch={this.onPullRemoteBranch}
         onRenameBranch={this.onRenameBranch}
         onSetAsDefaultBranch={this.onSetAsDefaultBranch}
         underlineLinks={this.props.underlineLinks}
@@ -441,6 +442,52 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       branch,
       existsOnRemote: aheadBehind !== null,
     })
+  }
+
+  private onPullRemoteBranch = async (branchName: string) => {
+    const branch = this.getBranchWithName(branchName)
+    const { dispatcher, repository } = this.props
+
+    if (branch === undefined) {
+      return
+    }
+
+    // console.clear()
+    // console.log(repository, ' repository ')
+    // console.log(dispatcher, ' dispatcher ')
+    // console.log(branch, ' branch ')
+    // console.log(BranchType, ' BranchType ')
+
+    if (branch.type === BranchType.Remote) {
+      // dispatcher.showPopup({
+      //   type: PopupType.PullRemoteBranch,
+      //   repository,
+      //   branch,
+      //   existsOnRemote: true,
+      // })
+
+      dispatcher.pullRemoteBranch(repository, branch)
+    }
+
+    // if (branch.type === BranchType.Remote) {
+    //   dispatcher.showPopup({
+    //     type: PopupType.DeleteRemoteBranch,
+    //     repository,
+    //     branch,
+    //   })
+    //   return
+    // }
+
+    // const aheadBehind = await dispatcher.getBranchAheadBehind(
+    //   repository,
+    //   branch
+    // )
+    // dispatcher.showPopup({
+    //   type: PopupType.DeleteBranch,
+    //   repository,
+    //   branch,
+    //   existsOnRemote: aheadBehind !== null,
+    // })
   }
 
   private onBadgeClick = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -118,7 +118,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         branchSortOrder={this.props.branchSortOrder}
         emoji={this.props.emoji}
         onDeleteBranch={this.onDeleteBranch}
-        onFetchRemoteBranch={this.onFetchRemoteBranch}
+        onFetchRemoteOrLocalBranch={this.onFetchRemoteOrLocalBranch}
         onRenameBranch={this.onRenameBranch}
         onSetAsDefaultBranch={this.onSetAsDefaultBranch}
         underlineLinks={this.props.underlineLinks}
@@ -317,12 +317,10 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     }
 
     const { name, type, nameWithoutRemote } = tip.branch
-    const isDefault = nameWithoutRemote === this.props.repository.defaultBranch
     const items = generateBranchContextMenuItems({
       name,
       nameWithoutRemote,
       isLocal: type === BranchType.Local,
-      isDefault,
       isCurrentBranch: true,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree: false,
@@ -335,7 +333,10 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       onViewPullRequestOnGitHub: this.props.currentPullRequest
         ? this.onViewPullRequestOnGithub
         : undefined,
-      onSetAsDefaultBranch: isDefault ? undefined : this.onSetAsDefaultBranch,
+      onSetAsDefaultBranch:
+        nameWithoutRemote === this.props.repository.defaultBranch
+          ? undefined
+          : this.onSetAsDefaultBranch,
       onDeleteBranch: this.onDeleteBranch,
     })
 
@@ -444,18 +445,16 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     })
   }
 
-  private onFetchRemoteBranch = (branchName: string) => {
+  private onFetchRemoteOrLocalBranch = (branchName: string) => {
     const branch = this.getBranchWithName(branchName)
-    const { dispatcher, repository } = this.props
-
     if (!branch) {
       return
     }
 
-    // Only fetch remote branch
-    // if (branch.type === BranchType.Remote) {
-    // }
-    dispatcher.fetchRemoteBranch(repository, branch)
+    this.props.dispatcher.fetchRemoteOrLocalBranch(
+      this.props.repository,
+      branch
+    )
   }
 
   private onBadgeClick = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -118,7 +118,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         branchSortOrder={this.props.branchSortOrder}
         emoji={this.props.emoji}
         onDeleteBranch={this.onDeleteBranch}
-        onPullRemoteBranch={this.onPullRemoteBranch}
+        onFetchRemoteBranch={this.onFetchRemoteBranch}
         onRenameBranch={this.onRenameBranch}
         onSetAsDefaultBranch={this.onSetAsDefaultBranch}
         underlineLinks={this.props.underlineLinks}
@@ -444,50 +444,18 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     })
   }
 
-  private onPullRemoteBranch = async (branchName: string) => {
+  private onFetchRemoteBranch = (branchName: string) => {
     const branch = this.getBranchWithName(branchName)
     const { dispatcher, repository } = this.props
 
-    if (branch === undefined) {
+    if (!branch) {
       return
     }
 
-    // console.clear()
-    // console.log(repository, ' repository ')
-    // console.log(dispatcher, ' dispatcher ')
-    // console.log(branch, ' branch ')
-    // console.log(BranchType, ' BranchType ')
-
+    // Only fetch remote branch
     if (branch.type === BranchType.Remote) {
-      // dispatcher.showPopup({
-      //   type: PopupType.PullRemoteBranch,
-      //   repository,
-      //   branch,
-      //   existsOnRemote: true,
-      // })
-
-      dispatcher.pullRemoteBranch(repository, branch)
+      dispatcher.fetchRemoteBranch(repository, branch)
     }
-
-    // if (branch.type === BranchType.Remote) {
-    //   dispatcher.showPopup({
-    //     type: PopupType.DeleteRemoteBranch,
-    //     repository,
-    //     branch,
-    //   })
-    //   return
-    // }
-
-    // const aheadBehind = await dispatcher.getBranchAheadBehind(
-    //   repository,
-    //   branch
-    // )
-    // dispatcher.showPopup({
-    //   type: PopupType.DeleteBranch,
-    //   repository,
-    //   branch,
-    //   existsOnRemote: aheadBehind !== null,
-    // })
   }
 
   private onBadgeClick = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -323,6 +323,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       nameWithoutRemote,
       isLocal: type === BranchType.Local,
       isDefault,
+      isCurrentBranch: true,
       repoType: this.props.repository.gitHubRepository?.type,
       isInUseByOtherWorktree: false,
       onRenameBranch: this.onRenameBranch,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #173

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This adds a **Pull branch** option to the right click context menu for remote
branches in the branch dropdown. Selecting it fetches the specific branch
from the remote, updating its tracking reference without switching branches.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="362" height="574" alt="Screenshot From 2026-06-04 22-57-56" src="https://github.com/user-attachments/assets/8a9e6f07-a78f-4efa-b052-778dc82e02d0" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
