### PR TITLE
feat: add 'Open in Terminal' row to suggested actions panel

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -234,6 +234,12 @@ export interface IDailyMeasures {
   readonly suggestedStepOpenWorkingDirectory: number
 
   /**
+   * The number of times the user has opened their repository in terminal
+   * from the suggested next steps view
+   */
+  readonly suggestedStepOpenInShell: number
+
+  /**
    * The number of times the user has opened their repository on GitHub from the
    * suggested next steps view
    */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -150,6 +150,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   noActionTakenOnStashCount: 0,
   suggestedStepOpenInExternalEditor: 0,
   suggestedStepOpenWorkingDirectory: 0,
+  suggestedStepOpenInShell: 0,
   suggestedStepViewOnGitHub: 0,
   suggestedStepPublishRepository: 0,
   suggestedStepPublishBranch: 0,

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -369,6 +369,38 @@ export class NoChanges extends React.Component<
   private onOpenInExternalEditorClicked = () =>
     this.props.dispatcher.incrementMetric('suggestedStepOpenInExternalEditor')
 
+  private renderOpenInShell() {
+    const itemId: MenuIDs = 'open-in-shell'
+    const menuItem = this.getMenuItemInfo(itemId)
+
+    if (menuItem === undefined) {
+      log.error(`Could not find matching menu item for ${itemId}`)
+      return null
+    }
+
+    const title = `Open the repository in terminal`
+
+    const description = (
+      <>
+        Select your terminal in{' '}
+        <LinkButton onClick={this.openIntegrationPreferences}>
+          {__DARWIN__ ? 'Settings' : 'Options'}
+        </LinkButton>
+      </>
+    )
+
+    return this.renderMenuBackedAction(
+      itemId,
+      title,
+      octicons.terminal,
+      description,
+      this.onOpenInShellClicked
+    )
+  }
+
+  private onOpenInShellClicked = () =>
+    this.props.dispatcher.incrementMetric('suggestedStepOpenInShell')
+
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState, tagsToPush } =
       this.props.repositoryState
@@ -803,6 +835,7 @@ export class NoChanges extends React.Component<
         </SuggestedActionGroup>
         <SuggestedActionGroup>
           {this.renderOpenInExternalEditor()}
+          {this.renderOpenInShell()}
           {this.renderShowInFileManager()}
           {this.renderViewOnGitHub()}
         </SuggestedActionGroup>


### PR DESCRIPTION
## Description
This PR adds a new separate row **"Open the repository in terminal"** to the "No local changes" suggested actions panel. This allows users to open their configured shell/terminal directly from the suggested actions when a repository has no changes, improving accessibility to terminal access.

### Key Changes:
- **UI Integration** `no-changes.tsx`:
  - Added a new `MenuBackedSuggestedAction` linked to the existing `'open-in-shell'` action ID.
  - Configured it with the `octicons.terminal` icon and a clear description pointing users to their Integration Preferences to change their default shell.
  - Placed the row between the "Open in External Editor" and "Show in File Manager" suggested action rows.
- **Telemetry & Stats**:
  - Added the `suggestedStepOpenInShell` metric to `stats-database.ts` and `stats-store.ts` to track user clicks on this new action daily.

### Screenshots

## OLD
<img width="618" height="282" alt="OLD" src="https://github.com/user-attachments/assets/425a4941-c1f1-4b27-b16e-337b47b686af" />

## NEW
<img width="556" height="336" alt="NEW" src="https://github.com/user-attachments/assets/8f0a4e09-9cca-493e-975f-1731914ce31e" />

## Release notes

Notes: Added an "Open the repository in terminal" suggested action when a repository has no local changes.