### PR TITLE
#193: Fixing the UI bug with the "Seach commits" input field

### DIFF
--- a/app/styles/ui/history/_commit-graph.scss
+++ b/app/styles/ui/history/_commit-graph.scss
@@ -11,6 +11,11 @@
       flex: 1 1 auto;
       min-width: 0;
       border-bottom: 0;
+
+      .fancy-text-box-component,
+      .text-box-component {
+        min-width: 0;
+      }
     }
 
     .commitGraph-view-mode-switch {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #193 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
When the History tab is resized to a small width, the "Search commits" input doesn't shrink enough and overlaps the adjacent "List view" / "Graph view" toggle buttons.

Root cause: .fancy-text-box-component and .text-box-component inside the flex toolbar retained the implicit min-width: auto default from the flexbox model, preventing the field from dropping below its intrinsic content size even though the parent .commit-search-form was allowed to shrink.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Originally:
<img width="487" height="85" alt="Bildschirmfoto_20260623_152050" src="https://github.com/user-attachments/assets/1f1d4543-17b9-4c58-bd4e-4c28b335b58f" />

With the fix:
<img width="487" height="85" alt="Bildschirmfoto_20260623_152057" src="https://github.com/user-attachments/assets/8a53207d-805d-4cbe-af3d-4a9abf20b28a" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: /
