### PR TITLE
Restore worktree family rows in the repository sidebar

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -70,7 +70,7 @@ import { IAPIRepoRuleset } from './api'
 import { ICustomIntegration } from './custom-integration'
 import { Emoji } from './emoji'
 import { IUpdateState } from '../ui/lib/update-store'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from './copilot/model'
 
 export enum SelectionType {
   Repository,
@@ -91,6 +91,11 @@ export type PossibleSelections =
     }
   | { type: SelectionType.MissingRepository; repository: Repository }
 
+export interface IRecentRepositorySelection {
+  readonly repositoryId: number
+  readonly path: string
+}
+
 /** All of the shared app state. */
 export interface IAppState {
   readonly accounts: ReadonlyArray<Account>
@@ -100,9 +105,9 @@ export interface IAppState {
   readonly repositories: ReadonlyArray<Repository | CloningRepository>
 
   /**
-   * List of IDs of the most recently opened repositories (most recent first)
+   * List of the most recently opened repository/worktree paths (most recent first)
    */
-  readonly recentRepositories: ReadonlyArray<number>
+  readonly recentRepositories: ReadonlyArray<IRecentRepositorySelection>
 
   /**
    * A cache of the latest repository state values, keyed by the repository id
@@ -342,6 +347,9 @@ export interface IAppState {
 
   /** Whether or not recent repositories should be shown in the repo list */
   readonly showRecentRepositories: boolean
+
+  /** Maximum number of recently selected repositories to remember */
+  readonly recentRepositoriesLength: number
 
   /** Whether or not the worktrees dropdown should be shown in the toolbar */
   readonly showWorktrees: boolean

--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -1,4 +1,4 @@
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from './model'
 import {
   DefaultConflictResolutionReasoningEffort,
   getPreferredDefaultModel,

--- a/app/src/lib/copilot/model.ts
+++ b/app/src/lib/copilot/model.ts
@@ -1,0 +1,45 @@
+import type {
+  ModelBilling as SDKModelBilling,
+  ModelInfo,
+} from '@github/copilot-sdk'
+
+/**
+ * Extra usage-billing metadata currently returned by Copilot model listing
+ * responses but not represented in the public SDK ModelInfo type.
+ */
+export interface ICopilotModelBillingTokenPrices {
+  readonly batchSize?: number
+  readonly cachePrice?: number
+  readonly contextMax?: number
+  readonly inputPrice?: number
+  readonly outputPrice?: number
+}
+
+export type CopilotModelBilling = Omit<SDKModelBilling, 'multiplier'> & {
+  readonly multiplier?: SDKModelBilling['multiplier']
+  readonly tokenPrices?: ICopilotModelBillingTokenPrices
+}
+
+type CopilotModelCapabilitiesLimits = Omit<
+  ModelInfo['capabilities']['limits'],
+  'max_context_window_tokens'
+> & {
+  readonly max_context_window_tokens?: number
+  readonly max_output_tokens?: number
+}
+
+type CopilotModelCapabilities = Omit<ModelInfo['capabilities'], 'limits'> & {
+  readonly limits: CopilotModelCapabilitiesLimits
+}
+
+/**
+ * Desktop consumes a few model-picker metadata fields ahead of the public SDK
+ * type surface. Keep them local and optional so the app can handle SDKs that
+ * do or do not expose them.
+ */
+export type CopilotModel = Omit<ModelInfo, 'billing' | 'capabilities'> & {
+  readonly capabilities: CopilotModelCapabilities
+  readonly billing?: CopilotModelBilling
+  readonly modelPickerCategory?: string
+  readonly modelPickerPriceCategory?: string
+}

--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -144,6 +144,10 @@ export async function removeWorktree(
   await git(args, repositoryPath, 'removeWorktree')
 }
 
+export async function pruneWorktrees(repository: Repository): Promise<void> {
+  await git(['worktree', 'prune'], repository.path, 'pruneWorktrees')
+}
+
 export async function moveWorktree(
   repository: Repository,
   oldPath: string,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -167,6 +167,7 @@ import {
   ICompareFormUpdate,
   ICompareToBranch,
   IDisplayHistory,
+  IRecentRepositorySelection,
   PossibleSelections,
   RepositorySectionTab,
   SelectionType,
@@ -288,7 +289,10 @@ import { hasShownWelcomeFlow, markWelcomeFlowComplete } from '../welcome'
 import { WindowState } from '../window-state'
 import { TypedBaseStore } from './base-store'
 import { MergeTreeResult } from '../../models/merge'
-import { promiseWithMinimumTimeout } from '../promise'
+import {
+  parallelWithConcurrencyLimit,
+  promiseWithMinimumTimeout,
+} from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
 import { RepositoryStateCache } from './repository-state-cache'
 import {
@@ -437,6 +441,7 @@ import {
 import { updateStore } from '../../ui/lib/update-store'
 import { startTimer } from '../../ui/lib/timing'
 import { BypassReasonType } from '../../ui/secret-scanning/bypass-push-protection-dialog'
+import { normalizePath } from '../helpers/path'
 import {
   selectReferencedContext,
   fallbackReferencedContext,
@@ -457,7 +462,7 @@ import {
 } from '../pull-request-refs'
 import { resolveWithin } from '../path'
 import { WorktreeEntry } from '../../models/worktree'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../copilot/model'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -469,11 +474,66 @@ const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 const MaxPullRequestLookups = 10
 
 const RecentRepositoriesKey = 'recently-selected-repositories'
+const RecentRepositorySelectionsKey = 'recently-selected-repository-selections'
+const RecentRepositoriesLengthKey = 'recent-repositories-length'
 /**
  *  maximum number of repositories shown in the "Recent" repositories group
  *  in the repository switcher dropdown
  */
-const RecentRepositoriesLength = 3
+export const recentRepositoriesLengthDefault = 3
+
+const constrainRecentRepositoriesLength = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return recentRepositoriesLengthDefault
+  }
+
+  return Math.max(1, Math.min(50, Math.round(value)))
+}
+
+const isRecentRepositorySelection = (
+  value: unknown
+): value is IRecentRepositorySelection => {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  const selection = value as Partial<IRecentRepositorySelection>
+  return (
+    typeof selection.repositoryId === 'number' &&
+    Number.isFinite(selection.repositoryId) &&
+    typeof selection.path === 'string' &&
+    selection.path.length > 0
+  )
+}
+
+const loadRecentRepositorySelections = (
+  repositories: ReadonlyArray<Repository>,
+  length: number
+): ReadonlyArray<IRecentRepositorySelection> => {
+  const storedSelections = getObject<ReadonlyArray<unknown>>(
+    RecentRepositorySelectionsKey
+  )
+
+  if (Array.isArray(storedSelections)) {
+    return storedSelections.filter(isRecentRepositorySelection).slice(0, length)
+  }
+
+  const repositoryById = new Map(
+    repositories.map(repository => [repository.id, repository])
+  )
+
+  return getNumberArray(RecentRepositoriesKey)
+    .map(repositoryId => {
+      const repository = repositoryById.get(repositoryId)
+      return repository === undefined
+        ? null
+        : { repositoryId, path: repository.path }
+    })
+    .filter(
+      (selection): selection is IRecentRepositorySelection => selection !== null
+    )
+    .slice(0, length)
+}
 
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
@@ -554,6 +614,7 @@ const shellKey = 'shell'
 const showRecentRepositoriesKey = 'show-recent-repositories'
 const showWorktreesKey = 'show-worktrees-foldout'
 const showWorktreesInRepoListKey = 'show-worktrees-in-repo-list'
+const showWorktreesInRepoListDefault = true
 const showCompareTabKey = 'show-compare-tab'
 const showCompareTabDefault = true
 const showConventionalCommitBadgesKey = 'show-conventional-commit-badges'
@@ -621,7 +682,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
-  private recentRepositories: ReadonlyArray<number> = new Array<number>()
+  private recentRepositories: ReadonlyArray<IRecentRepositorySelection> =
+    new Array<IRecentRepositorySelection>()
+  private recentRepositoriesLength: number = recentRepositoriesLengthDefault
 
   private selectedRepository: Repository | CloningRepository | null = null
 
@@ -744,7 +807,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private titleBarStyle: TitleBarStyle = __WIN32__ ? 'custom' : 'native'
   private showRecentRepositories: boolean = true
   private showWorktrees: boolean = false
-  private showWorktreesInRepoList: boolean = false
+  private showWorktreesInRepoList: boolean = showWorktreesInRepoListDefault
   private showCompareTab: boolean = showCompareTabDefault
   private showConventionalCommitBadges: boolean =
     showConventionalCommitBadgesDefault
@@ -878,9 +941,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
       getBoolean(repositoryIndicatorsEnabledKey) ?? true
 
     this.showRecentRepositories = getBoolean(showRecentRepositoriesKey) ?? true
+    this.recentRepositoriesLength = constrainRecentRepositoriesLength(
+      getNumber(RecentRepositoriesLengthKey, recentRepositoriesLengthDefault)
+    )
+    this.recentRepositories = loadRecentRepositorySelections(
+      this.repositories,
+      this.recentRepositoriesLength
+    )
     this.showWorktrees = getBoolean(showWorktreesKey) ?? true
     this.showWorktreesInRepoList =
-      getBoolean(showWorktreesInRepoListKey) ?? false
+      getBoolean(showWorktreesInRepoListKey) ?? showWorktreesInRepoListDefault
     this.showCompareTab = getBoolean(showCompareTabKey, showCompareTabDefault)
     this.showConventionalCommitBadges = getBoolean(
       showConventionalCommitBadgesKey,
@@ -1326,6 +1396,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       accounts: this.accounts,
       repositories,
       recentRepositories: this.recentRepositories,
+      recentRepositoriesLength: this.recentRepositoriesLength,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
@@ -2575,11 +2646,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       setNumber(LastSelectedRepositoryIDKey, repository.id)
     }
 
-    const previousRepositoryId = previouslySelectedRepository
-      ? previouslySelectedRepository.id
-      : null
-
-    this.updateRecentRepositories(previousRepositoryId, repository.id)
+    this.updateRecentRepositories(previouslySelectedRepository, repository)
 
     // if repository might be marked missing, try checking if it has been restored
     const refreshedRepository = await this.recoverMissingRepository(repository)
@@ -2614,34 +2681,100 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
   }
 
-  // update the stored list of recently opened repositories
-  private updateRecentRepositories(
-    previousRepositoryId: number | null,
-    currentRepositoryId: number
+  private getRecentRepositorySelection(
+    repository: Repository | CloningRepository | null
+  ): IRecentRepositorySelection | null {
+    return repository instanceof Repository
+      ? { repositoryId: repository.id, path: repository.path }
+      : null
+  }
+
+  private areRecentRepositorySelectionsEqual(
+    first: IRecentRepositorySelection,
+    second: IRecentRepositorySelection
+  ): boolean {
+    return (
+      first.repositoryId === second.repositoryId &&
+      normalizePath(first.path) === normalizePath(second.path)
+    )
+  }
+
+  private setRecentRepositories(
+    recentRepositories: ReadonlyArray<IRecentRepositorySelection>
   ) {
-    // No need to update the recent repositories if the selected repository is
-    // the same as the old one (this could happen when the alias of the selected
-    // repository is changed).
-    if (previousRepositoryId === currentRepositoryId) {
+    const slicedRecentRepositories = recentRepositories.slice(
+      0,
+      this.recentRepositoriesLength
+    )
+    setObject(RecentRepositorySelectionsKey, slicedRecentRepositories)
+    setNumberArray(
+      RecentRepositoriesKey,
+      slicedRecentRepositories.map(selection => selection.repositoryId)
+    )
+    this.recentRepositories = slicedRecentRepositories
+    this.notificationsStore.setRecentRepositories(
+      this.repositories.filter(r =>
+        this.recentRepositories.some(
+          selection => selection.repositoryId === r.id
+        )
+      )
+    )
+    this.emitUpdate()
+  }
+
+  private loadRecentRepositoriesFromStorage() {
+    this.recentRepositories = loadRecentRepositorySelections(
+      this.repositories,
+      this.recentRepositoriesLength
+    )
+    setObject(RecentRepositorySelectionsKey, this.recentRepositories)
+    setNumberArray(
+      RecentRepositoriesKey,
+      this.recentRepositories.map(selection => selection.repositoryId)
+    )
+    this.notificationsStore.setRecentRepositories(
+      this.repositories.filter(r =>
+        this.recentRepositories.some(
+          selection => selection.repositoryId === r.id
+        )
+      )
+    )
+  }
+
+  // update the stored list of recently opened repository/worktree selections
+  private updateRecentRepositories(
+    previousRepository: Repository | CloningRepository | null,
+    currentRepository: Repository
+  ) {
+    const previousSelection =
+      this.getRecentRepositorySelection(previousRepository)
+    const currentSelection =
+      this.getRecentRepositorySelection(currentRepository)
+
+    if (previousSelection === null || currentSelection === null) {
       return
     }
 
-    const recentRepositories = getNumberArray(RecentRepositoriesKey).filter(
-      el => el !== currentRepositoryId && el !== previousRepositoryId
-    )
-    if (previousRepositoryId !== null) {
-      recentRepositories.unshift(previousRepositoryId)
+    // No need to update the recent repositories if the selected repository is
+    // the same as the old one (this could happen when the alias of the selected
+    // repository is changed).
+    if (
+      this.areRecentRepositorySelectionsEqual(
+        previousSelection,
+        currentSelection
+      )
+    ) {
+      return
     }
-    const slicedRecentRepositories = recentRepositories.slice(
-      0,
-      RecentRepositoriesLength
+
+    const recentRepositories = this.recentRepositories.filter(
+      selection =>
+        !this.areRecentRepositorySelectionsEqual(selection, currentSelection) &&
+        !this.areRecentRepositorySelectionsEqual(selection, previousSelection)
     )
-    setNumberArray(RecentRepositoriesKey, slicedRecentRepositories)
-    this.recentRepositories = slicedRecentRepositories
-    this.notificationsStore.setRecentRepositories(
-      this.repositories.filter(r => this.recentRepositories.includes(r.id))
-    )
-    this.emitUpdate()
+    recentRepositories.unshift(previousSelection)
+
+    this.setRecentRepositories(recentRepositories)
   }
 
   // finish `_selectRepository`s refresh tasks
@@ -2876,6 +3009,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accounts = accounts
     this.repositories = repositories
+    this.loadRecentRepositoriesFromStorage()
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
 
@@ -3136,6 +3270,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdateNow()
 
     this.accountsStore.refresh()
+
+    if (this.showWorktreesInRepoList) {
+      this.refreshAllWorktreesForRepoList().catch(e =>
+        log.error('Failed to refresh repository list worktrees at startup', e)
+      )
+    }
 
     this.updateMenuLabelsForSelectedRepository()
   }
@@ -4818,6 +4958,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  public _setRecentRepositoriesLength(recentRepositoriesLength: number) {
+    const constrainedLength = constrainRecentRepositoriesLength(
+      recentRepositoriesLength
+    )
+
+    if (this.recentRepositoriesLength === constrainedLength) {
+      return
+    }
+
+    this.recentRepositoriesLength = constrainedLength
+    setNumber(RecentRepositoriesLengthKey, constrainedLength)
+
+    this.setRecentRepositories(this.recentRepositories)
+  }
+
   public _setShowWorktrees(showWorktrees: boolean) {
     if (this.showWorktrees === showWorktrees) {
       return
@@ -4844,22 +4999,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async refreshAllWorktreesForRepoList(): Promise<void> {
     const lookup = this.localRepositoryStateLookup
+    const repositories = this.repositories.filter(
+      repository => !repository.missing
+    )
 
-    for (const repository of this.repositories) {
-      if (repository.missing) {
-        continue
-      }
+    await parallelWithConcurrencyLimit(
+      repositories,
+      async repository => {
+        const worktrees = await this.loadWorktreesForRepoList(repository)
+        const existing = lookup.get(repository.id)
+        lookup.set(repository.id, {
+          aheadBehind: existing?.aheadBehind ?? null,
+          changedFilesCount: existing?.changedFilesCount ?? 0,
+          branchName: existing?.branchName ?? null,
+          defaultBranchName: existing?.defaultBranchName ?? null,
+          worktrees,
+        })
 
-      const worktrees = await this.loadWorktreesForRepoList(repository)
-      const existing = lookup.get(repository.id)
-      lookup.set(repository.id, {
-        aheadBehind: existing?.aheadBehind ?? null,
-        changedFilesCount: existing?.changedFilesCount ?? 0,
-        branchName: existing?.branchName ?? null,
-        defaultBranchName: existing?.defaultBranchName ?? null,
-        worktrees,
-      })
-    }
+        if (worktrees.length > 1) {
+          this.emitUpdate()
+        }
+      },
+      4
+    )
 
     this.emitUpdate()
   }
@@ -7062,6 +7224,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    await this.repositoriesStore.removeRepositoryForPath(worktreePath)
     await this._refreshWorktrees(repository)
     this.statsStore.increment('worktreeDeletedCount')
   }

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1,7 +1,5 @@
-import {
-  CopilotClient,
-  CopilotSession,
-  RuntimeConnection,
+import { CopilotClient, CopilotSession } from '@github/copilot-sdk'
+import type {
   AssistantMessageEvent,
   MessageOptions,
   SessionConfig,
@@ -42,9 +40,9 @@ import { IRepoRulesMetadataRule } from '../../models/repo-rules'
 import { pathExists } from '../path-exists'
 import { enableCopilotSdkCommitMessageGeneration } from '../feature-flag'
 import type {
-  Model,
-  ModelBillingTokenPrices,
-} from '@github/copilot-sdk/dist/generated/rpc'
+  CopilotModel as Model,
+  ICopilotModelBillingTokenPrices,
+} from '../copilot/model'
 import { isGHE } from '../endpoint-capabilities'
 
 /** The default model ID used for Copilot commit message generation. */
@@ -401,7 +399,9 @@ function getModelBillingKind(
   return models.some(m => m.billing?.tokenPrices !== undefined) ? 'usage' : null
 }
 
-function getTokenPriceCost(tokenPrices: ModelBillingTokenPrices): number {
+function getTokenPriceCost(
+  tokenPrices: ICopilotModelBillingTokenPrices
+): number {
   const { batchSize, inputPrice, outputPrice } = tokenPrices
   if (
     batchSize === undefined ||
@@ -754,11 +754,12 @@ export class CopilotStore extends BaseStore {
       : indexPath
 
     return new CopilotClient({
-      connection: RuntimeConnection.forStdio({
-        path: await getCopilotCLIPath(),
-        args: ['--eval', `import '${importSpecifier}'`, '--'],
-      }),
+      cliPath: await getCopilotCLIPath(),
+      cliArgs: ['--eval', `import '${importSpecifier}'`, '--'],
+      cwd: repositoryPath,
+      useStdio: true,
       env: {
+        ...process.env,
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',
         GH_HOST: getCopilotGHHost(account),
@@ -766,7 +767,6 @@ export class CopilotStore extends BaseStore {
           __DEV__ ? '-dev' : ''
         }`,
       },
-      workingDirectory: repositoryPath,
       gitHubToken: account.token,
     })
   }
@@ -1475,14 +1475,14 @@ export class CopilotStore extends BaseStore {
 
     try {
       await client.start()
-      // HACK(copilot-sdk): using `Model` (from RPC API) instead of `ModelInfo`
-      // in order to get the new billing metadata fields that are not available
-      // yet in the `ModelInfo` type returned by `CopilotClient.listModels()`.
+      // HACK(copilot-sdk): cast to Desktop's extended model type in order to
+      // get the new billing metadata fields that are not available yet in the
+      // `ModelInfo` type returned by `CopilotClient.listModels()`.
       // This is safe because CopilotClient just force-casts the RPC response
       // (a list of `Model`) to `ModelInfo`, so the underlying data is the same
       // and we just get more fields by using the RPC type directly.
       // We can switch back to `ModelInfo` once the SDK updates its types.
-      return await client.listModels()
+      return (await client.listModels()) as ReadonlyArray<Model>
     } finally {
       await this.stopClient(client)
     }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -301,6 +301,19 @@ export class RepositoriesStore extends TypedBaseStore<
     this.emitUpdatedRepositories()
   }
 
+  /** Remove and return the repository saved at the given path, if any. */
+  public async removeRepositoryForPath(
+    path: string
+  ): Promise<Repository | null> {
+    const repository = await this.getRepositoryForPath(path)
+    if (repository === null) {
+      return null
+    }
+
+    await this.removeRepository(repository)
+    return repository
+  }
+
   /** Update the repository's `missing` flag. */
   public async updateRepositoryMissing(
     repository: Repository,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1176,10 +1176,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         repository instanceof Repository
           ? repository.alias ?? repository.name
           : repository.name
-      return `${repositoryTitle} - Desktop Plus`
+      return `${repositoryTitle} - ${getName()}`
     }
 
-    return 'Desktop Plus'
+    return getName()
   }
 
   private updateWindowTitle() {
@@ -1863,6 +1863,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             branchPresetScript={this.state.branchPresetScript}
             titleBarStyle={this.state.titleBarStyle}
             showRecentRepositories={this.state.showRecentRepositories}
+            recentRepositoriesLength={this.state.recentRepositoriesLength}
             showWorktrees={this.state.showWorktrees}
             showWorktreesInRepoList={this.state.showWorktreesInRepoList}
             showCompareTab={this.state.showCompareTab}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3197,6 +3197,10 @@ export class Dispatcher {
     this.appStore._setShowRecentRepositories(showRecentRepositories)
   }
 
+  public setRecentRepositoriesLength(recentRepositoriesLength: number) {
+    this.appStore._setRecentRepositoriesLength(recentRepositoriesLength)
+  }
+
   public setShowWorktrees(showWorktrees: boolean) {
     this.appStore._setShowWorktrees(showWorktrees)
   }

--- a/app/src/ui/lib/copilot-model-picker.tsx
+++ b/app/src/ui/lib/copilot-model-picker.tsx
@@ -12,9 +12,9 @@ import { PopoverDecoration } from './popover'
 import { PopoverDropdown } from './popover-dropdown'
 import { SectionFilterList } from './section-filter-list'
 import type {
-  Model,
-  ModelBilling,
-} from '@github/copilot-sdk/dist/generated/rpc'
+  CopilotModel as Model,
+  CopilotModelBilling as ModelBilling,
+} from '../../lib/copilot/model'
 
 interface ICopilotModelPickerProps {
   readonly label: string

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1394,7 +1394,8 @@ export class SectionList extends React.Component<
           )}
           scrollTop={relativeScrollTop}
           overscanRowCount={4}
-          style={{ ...params.style, width: '100%' }}
+          style={{ ...params.style, width: '100%', overflow: 'hidden' }}
+          containerStyle={{ overflow: 'hidden' }}
           tabIndex={-1}
           aria-label={this.props.getSectionAriaLabel?.(section)}
         />

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -163,6 +163,13 @@ interface ISectionFilterListProps<T extends IFilterListItem, GroupIdentifier> {
   readonly renderNoItems?: () => JSX.Element | null
 
   /**
+   * Whether filtered results should preserve the incoming item order instead
+   * of being sorted by fuzzy score. Use this when item order carries hierarchy.
+   */
+  // eslint-disable-next-line react/no-unused-prop-types
+  readonly preserveItemOrderWhenFiltering?: boolean
+
+  /**
    * A reference to a TextBox that will be used to control this component.
    *
    * See https://github.com/desktop/desktop/issues/4317 for refactoring work to
@@ -708,6 +715,29 @@ export function getText<T extends IFilterListItem>(
   return item['text']
 }
 
+export function getFilteredItems<T extends IFilterListItem>(
+  filter: string,
+  items: ReadonlyArray<T>,
+  preserveItemOrderWhenFiltering?: boolean
+): ReadonlyArray<IMatch<T>> {
+  const filteredItems: ReadonlyArray<IMatch<T>> = filter
+    ? match(filter, items, getText)
+    : items.map(item => ({
+        score: 1,
+        matches: { title: [], subtitle: [] },
+        item,
+      }))
+
+  if (!filter || preserveItemOrderWhenFiltering !== true) {
+    return filteredItems
+  }
+
+  const order = new Map(items.map((item, index) => [item.id, index]))
+  return [...filteredItems].sort(
+    (x, y) => (order.get(x.item.id) ?? 0) - (order.get(y.item.id) ?? 0)
+  )
+}
+
 function getFirstVisibleRow<T extends IFilterListItem, GroupIdentifier>(
   rows: ReadonlyArray<ReadonlyArray<IFilterListRow<T, GroupIdentifier>>>
 ): RowIndexPath {
@@ -762,13 +792,11 @@ function createStateUpdate<T extends IFilterListItem, GroupIdentifier>(
 
   for (const [idx, group] of props.groups.entries()) {
     const groupRows = new Array<IFilterListRow<T, GroupIdentifier>>()
-    const items: ReadonlyArray<IMatch<T>> = filter
-      ? match(filter, group.items, getText)
-      : group.items.map(item => ({
-          score: 1,
-          matches: { title: [], subtitle: [] },
-          item,
-        }))
+    const items = getFilteredItems(
+      filter,
+      group.items,
+      props.preserveItemOrderWhenFiltering
+    )
 
     if (!items.length) {
       continue

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -71,7 +71,16 @@ export interface ITextBoxProps {
   readonly onEnterPressed?: (text: string) => void
 
   /** The type of the input. Defaults to `text`. */
-  readonly type?: 'text' | 'search' | 'password' | 'email'
+  readonly type?: 'text' | 'search' | 'password' | 'email' | 'number'
+
+  /** Minimum value for numeric inputs. */
+  readonly min?: number | string
+
+  /** Maximum value for numeric inputs. */
+  readonly max?: number | string
+
+  /** Step value for numeric inputs. */
+  readonly step?: number | string
 
   /** The tab index of the input element. */
   readonly tabIndex?: number
@@ -217,12 +226,20 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     const value = event.currentTarget.value
     const isComposing =
       event.nativeEvent instanceof InputEvent && event.nativeEvent.isComposing
-    const cursorPosition = isComposing
-      ? undefined
-      : {
-          start: event.currentTarget.selectionStart ?? 0,
-          end: event.currentTarget.selectionEnd ?? 0,
-        }
+    const canTrackCursor = [
+      'text',
+      'search',
+      'url',
+      'tel',
+      'password',
+    ].includes(event.currentTarget.type)
+    const cursorPosition =
+      isComposing || !canTrackCursor
+        ? undefined
+        : {
+            start: event.currentTarget.selectionStart ?? 0,
+            end: event.currentTarget.selectionEnd ?? 0,
+          }
 
     // Even when the new value is '', we don't want to render the aria-live
     // message saying "input cleared", so we set valueCleared to false.
@@ -361,6 +378,9 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           disabled={this.props.disabled}
           readOnly={this.props.readOnly}
           type={this.props.type ?? 'text'}
+          min={this.props.min}
+          max={this.props.max}
+          step={this.props.step}
           placeholder={this.props.placeholder}
           value={this.state.value}
           onChange={this.onChange}

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -16,6 +16,7 @@ import { ShowBranchNameInRepoListSetting } from '../../models/show-branch-name-i
 import { parseEnumValue } from '../../lib/enum'
 import { assertNever } from '../../lib/fatal-error'
 import { BranchSortOrder } from '../../models/branch-sort-order'
+import { TextBox } from '../lib/text-box'
 import {
   availableDiffFontSizes,
   defaultDiffFontFamily,
@@ -51,6 +52,8 @@ interface IAppearanceProps {
   readonly onTitleBarStyleChanged: (titleBarStyle: TitleBarStyle) => void
   readonly showRecentRepositories: boolean
   readonly onShowRecentRepositoriesChanged: (show: boolean) => void
+  readonly recentRepositoriesLength: number
+  readonly onRecentRepositoriesLengthChanged: (length: number) => void
   readonly showWorktrees: boolean
   readonly onShowWorktreesChanged: (show: boolean) => void
   readonly showWorktreesInRepoList: boolean
@@ -83,6 +86,7 @@ interface IAppearanceState {
   readonly availableDiffFontFamilies: ReadonlyArray<DiffFontFamily>
   readonly titleBarStyle: TitleBarStyle
   readonly showRecentRepositories: boolean
+  readonly recentRepositoriesLength: number
   readonly showWorktrees: boolean
   readonly showWorktreesInRepoList: boolean
   readonly showCompareTab: boolean
@@ -122,6 +126,7 @@ export class Appearance extends React.Component<
           : [props.selectedDiffFontFamily, defaultDiffFontFamily],
       titleBarStyle: props.titleBarStyle,
       showRecentRepositories: props.showRecentRepositories,
+      recentRepositoriesLength: props.recentRepositoriesLength,
       showWorktrees: props.showWorktrees,
       showWorktreesInRepoList: props.showWorktreesInRepoList,
       showCompareTab: props.showCompareTab,
@@ -161,6 +166,7 @@ export class Appearance extends React.Component<
       selectedDiffFontFamily,
       showWorktrees: this.props.showWorktrees,
       showWorktreesInRepoList: this.props.showWorktreesInRepoList,
+      recentRepositoriesLength: this.props.recentRepositoriesLength,
       showCompareTab: this.props.showCompareTab,
       showConventionalCommitBadges: this.props.showConventionalCommitBadges,
     })
@@ -203,6 +209,16 @@ export class Appearance extends React.Component<
     const show = event.currentTarget.checked
     this.setState({ showRecentRepositories: show })
     this.props.onShowRecentRepositoriesChanged(show)
+  }
+
+  private onRecentRepositoriesLengthChanged = (value: string) => {
+    const length = parseInt(value, 10)
+    if (!Number.isFinite(length)) {
+      return
+    }
+
+    this.setState({ recentRepositoriesLength: length })
+    this.props.onRecentRepositoriesLengthChanged(length)
   }
 
   private onShowWorktreesChanged = (
@@ -458,6 +474,16 @@ export class Appearance extends React.Component<
               : CheckboxValue.Off
           }
           onChange={this.onShowRecentRepositoriesChanged}
+        />
+        <TextBox
+          label="Recent repositories count"
+          type="number"
+          min={1}
+          max={50}
+          step={1}
+          value={this.state.recentRepositoriesLength.toString()}
+          onValueChanged={this.onRecentRepositoriesLengthChanged}
+          disabled={!this.state.showRecentRepositories}
         />
         <Select
           label="Show current branch name next to repository name"

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -29,7 +29,7 @@ import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { TabBar } from '../tab-bar'
 import { CopilotModelSelectionInfo } from './copilot-model-selection-info'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../../lib/copilot/model'
 
 interface ICopilotPreferencesProps {
   readonly selectedCopilotModels: CopilotModelSelections

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -87,7 +87,7 @@ import {
   setNumberFormatPreference,
 } from '../../models/formatting-preferences'
 import { enableFormattingPreferences } from '../../lib/feature-flag'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../../lib/copilot/model'
 
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
@@ -125,6 +125,7 @@ interface IPreferencesProps {
   readonly branchPresetScript: ICustomIntegration | null
   readonly titleBarStyle: TitleBarStyle
   readonly showRecentRepositories: boolean
+  readonly recentRepositoriesLength: number
   readonly showWorktrees: boolean
   readonly showWorktreesInRepoList: boolean
   readonly showCompareTab: boolean
@@ -181,6 +182,7 @@ interface IPreferencesState {
   readonly selectedShell: Shell
   readonly titleBarStyle: TitleBarStyle
   readonly showRecentRepositories: boolean
+  readonly recentRepositoriesLength: number
   readonly showWorktrees: boolean
   readonly showWorktreesInRepoList: boolean
   readonly showCompareTab: boolean
@@ -282,6 +284,7 @@ export class Preferences extends React.Component<
       selectedShell: this.props.selectedShell,
       titleBarStyle: this.props.titleBarStyle,
       showRecentRepositories: this.props.showRecentRepositories,
+      recentRepositoriesLength: this.props.recentRepositoriesLength,
       showWorktrees: this.props.showWorktrees,
       showWorktreesInRepoList: this.props.showWorktreesInRepoList,
       showCompareTab: this.props.showCompareTab,
@@ -720,6 +723,10 @@ export class Preferences extends React.Component<
             onShowRecentRepositoriesChanged={
               this.onShowRecentRepositoriesChanged
             }
+            recentRepositoriesLength={this.state.recentRepositoriesLength}
+            onRecentRepositoriesLengthChanged={
+              this.onRecentRepositoriesLengthChanged
+            }
             showWorktrees={this.state.showWorktrees}
             onShowWorktreesChanged={this.onShowWorktreesChanged}
             showWorktreesInRepoList={this.state.showWorktreesInRepoList}
@@ -1121,6 +1128,12 @@ export class Preferences extends React.Component<
     this.setState({ showRecentRepositories })
   }
 
+  private onRecentRepositoriesLengthChanged = (
+    recentRepositoriesLength: number
+  ) => {
+    this.setState({ recentRepositoriesLength })
+  }
+
   private onShowWorktreesChanged = (showWorktrees: boolean) => {
     this.setState({ showWorktrees })
   }
@@ -1216,6 +1229,15 @@ export class Preferences extends React.Component<
         this.state.showRecentRepositories !== this.props.showRecentRepositories
       ) {
         dispatcher.setShowRecentRepositories(this.state.showRecentRepositories)
+      }
+
+      if (
+        this.state.recentRepositoriesLength !==
+        this.props.recentRepositoriesLength
+      ) {
+        dispatcher.setRecentRepositoriesLength(
+          this.state.recentRepositoriesLength
+        )
       }
 
       if (this.state.showWorktrees !== this.props.showWorktrees) {

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -1,4 +1,5 @@
 import * as Path from 'path'
+
 import {
   Repository,
   ILocalRepositoryState,
@@ -15,6 +16,8 @@ import { WorktreeEntry } from '../../models/worktree'
 import { assertNever } from '../../lib/fatal-error'
 import { isGHE, isGHES } from '../../lib/endpoint-capabilities'
 import { Owner } from '../../models/owner'
+import { normalizePath } from '../../lib/helpers/path'
+import type { IRecentRepositorySelection } from '../../lib/app-state'
 
 export type RepositoryListGroup = (
   | {
@@ -61,12 +64,20 @@ export type Repositoryish = Repository | CloningRepository
 export interface IRepositoryListItem extends IFilterListItem {
   readonly text: ReadonlyArray<string>
   readonly id: string
+  readonly title: string
   readonly repository: Repositoryish
   readonly needsDisambiguation: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly changedFilesCount: number
   readonly branchName: string | null
   readonly defaultBranchName: string | null
+  readonly needsBranchNameDisambiguation: boolean
+  readonly worktreePathDisambiguation: string | null
+  readonly isNestedWorktree: boolean
+  readonly isPrunableWorktree: boolean
+  readonly isSyntheticWorktreeRoot: boolean
+  readonly sourceRepository: Repository | null
+  readonly familyMainPath: string | null
   /**
    * The worktree this row represents, when worktrees are shown in the list.
    *
@@ -105,18 +116,214 @@ const getGroupForRepository = (repo: Repositoryish): RepositoryListGroup => {
   return { kind: 'other', displayName: null }
 }
 
-type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
+type RepoGroupEntry = {
+  readonly repository: Repositoryish
+  readonly recentPath: string | null
+}
+
+type RepoGroupItem = { group: RepositoryListGroup; repos: RepoGroupEntry[] }
+
+export interface IGroupRepositoriesOptions {
+  /**
+   * Whether linked worktrees should be expanded into nested repository-list
+   * rows. Defaults to true for callers that do not have the preference.
+   */
+  readonly showWorktreesInRepoList?: boolean
+}
+
+const getMainWorktree = (
+  worktrees: ReadonlyArray<WorktreeEntry>
+): WorktreeEntry | null => worktrees.find(wt => wt.type === 'main') ?? null
+
+const getFamilyMainPath = (
+  repository: Repository,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+): string | null => {
+  const mainWorktree = getMainWorktree(
+    localRepositoryStateLookup.get(repository.id)?.worktrees ?? []
+  )
+
+  return mainWorktree !== null ? normalizePath(mainWorktree.path) : null
+}
+
+const getFamilyMainPathFromLoadedState = (
+  repository: Repository,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+): string | null => {
+  const directMainWorktreePath = getFamilyMainPath(
+    repository,
+    localRepositoryStateLookup
+  )
+
+  if (directMainWorktreePath !== null) {
+    return directMainWorktreePath
+  }
+
+  const repositoryPath = normalizePath(repository.path)
+  for (const state of localRepositoryStateLookup.values()) {
+    const mainWorktree = getMainWorktree(state.worktrees)
+    if (mainWorktree === null) {
+      continue
+    }
+
+    if (state.worktrees.some(wt => normalizePath(wt.path) === repositoryPath)) {
+      return normalizePath(mainWorktree.path)
+    }
+  }
+
+  return null
+}
+
+export function isRepositoryListItemPinned(
+  item: IRepositoryListItem,
+  pinnedIds: ReadonlyArray<number>,
+  repositories: ReadonlyArray<Repositoryish>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+): boolean {
+  if (!(item.repository instanceof Repository)) {
+    return false
+  }
+
+  const pinnedIdSet = new Set(pinnedIds)
+  if (pinnedIdSet.has(item.repository.id)) {
+    return true
+  }
+
+  if (item.familyMainPath === null) {
+    return false
+  }
+
+  return repositories.some(
+    repository =>
+      repository instanceof Repository &&
+      pinnedIdSet.has(repository.id) &&
+      getFamilyMainPathFromLoadedState(
+        repository,
+        localRepositoryStateLookup
+      ) === item.familyMainPath
+  )
+}
+
+const getWorktreeDisplayTitle = (
+  repository: Repository,
+  worktree: WorktreeEntry
+) =>
+  normalizePath(repository.path) === normalizePath(worktree.path) &&
+  repository.alias != null
+    ? repository.alias
+    : Path.basename(worktree.path)
+
+const mergeWorktrees = (
+  existing: ReadonlyArray<WorktreeEntry>,
+  incoming: ReadonlyArray<WorktreeEntry>
+): ReadonlyArray<WorktreeEntry> => {
+  const byPath = new Map<string, WorktreeEntry>()
+
+  for (const worktree of existing) {
+    byPath.set(normalizePath(worktree.path), worktree)
+  }
+
+  for (const worktree of incoming) {
+    byPath.set(normalizePath(worktree.path), worktree)
+  }
+
+  const worktrees = Array.from(byPath.values())
+  return [
+    ...worktrees.filter(worktree => worktree.type === 'main'),
+    ...worktrees.filter(worktree => worktree.type === 'linked'),
+  ]
+}
 
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  recentRepositories: ReadonlyArray<number>
+  recentRepositories: ReadonlyArray<IRecentRepositorySelection>,
+  options: IGroupRepositoriesOptions = {}
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
+  const showWorktreesInRepoList = options.showWorktreesInRepoList ?? true
   const includeRecentGroup = repositories.length > recentRepositoriesThreshold
-  const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
   const groups = new Map<string, RepoGroupItem>()
+  const repositoryByPath = new Map<string, Repository>()
+  const repositoryById = new Map<number, Repositoryish>()
+  const familySourceByMainPath = new Map<string, Repository>()
+  const familyMainPathByRepositoryId = new Map<number, string>()
+  const familyWorktreesByMainPath = new Map<
+    string,
+    ReadonlyArray<WorktreeEntry>
+  >()
 
-  const addToGroup = (group: RepositoryListGroup, repo: Repositoryish) => {
+  for (const repo of repositories) {
+    repositoryById.set(repo.id, repo)
+
+    if (!(repo instanceof Repository)) {
+      continue
+    }
+
+    const repositoryPath = normalizePath(repo.path)
+    repositoryByPath.set(repositoryPath, repo)
+  }
+
+  if (showWorktreesInRepoList) {
+    for (const repo of repositories) {
+      if (!(repo instanceof Repository)) {
+        continue
+      }
+
+      const mainWorktreePath = getFamilyMainPath(
+        repo,
+        localRepositoryStateLookup
+      )
+      if (mainWorktreePath === null) {
+        continue
+      }
+
+      familyMainPathByRepositoryId.set(repo.id, mainWorktreePath)
+
+      const worktrees = localRepositoryStateLookup.get(repo.id)?.worktrees ?? []
+      const existingWorktrees = familyWorktreesByMainPath.get(mainWorktreePath)
+      if (existingWorktrees === undefined) {
+        familyWorktreesByMainPath.set(mainWorktreePath, worktrees)
+      } else {
+        familyWorktreesByMainPath.set(
+          mainWorktreePath,
+          mergeWorktrees(existingWorktrees, worktrees)
+        )
+      }
+
+      if (!familySourceByMainPath.has(mainWorktreePath)) {
+        familySourceByMainPath.set(mainWorktreePath, repo)
+      }
+
+      for (const worktree of worktrees) {
+        const savedWorktreeRepository = repositoryByPath.get(
+          normalizePath(worktree.path)
+        )
+
+        if (savedWorktreeRepository !== undefined) {
+          familyMainPathByRepositoryId.set(
+            savedWorktreeRepository.id,
+            mainWorktreePath
+          )
+        }
+      }
+    }
+
+    for (const mainWorktreePath of familyWorktreesByMainPath.keys()) {
+      const mainRepository = repositoryByPath.get(mainWorktreePath)
+      if (mainRepository === undefined) {
+        continue
+      }
+
+      familySourceByMainPath.set(mainWorktreePath, mainRepository)
+      familyMainPathByRepositoryId.set(mainRepository.id, mainWorktreePath)
+    }
+  }
+
+  const addToGroup = (
+    group: RepositoryListGroup,
+    repo: Repositoryish,
+    recentPath: string | null = null
+  ) => {
     const key = getGroupKey(group)
     let rg = groups.get(key)
     if (!rg) {
@@ -124,12 +331,37 @@ export function groupRepositories(
       groups.set(key, rg)
     }
 
-    rg.repos.push(repo)
+    rg.repos.push({ repository: repo, recentPath })
+  }
+
+  if (includeRecentGroup) {
+    for (const recentRepository of recentRepositories) {
+      const repo =
+        repositoryByPath.get(normalizePath(recentRepository.path)) ??
+        repositoryById.get(recentRepository.repositoryId)
+      if (repo !== undefined) {
+        addToGroup(
+          { kind: 'recent', displayName: null },
+          repo,
+          recentRepository.path
+        )
+      }
+    }
   }
 
   for (const repo of repositories) {
-    if (recentSet?.has(repo.id) && repo instanceof Repository) {
-      addToGroup({ kind: 'recent', displayName: repo.groupName }, repo)
+    let mainWorktreePath: string | null = null
+
+    if (repo instanceof Repository && showWorktreesInRepoList) {
+      mainWorktreePath = familyMainPathByRepositoryId.get(repo.id) ?? null
+      const familySource =
+        mainWorktreePath !== null
+          ? familySourceByMainPath.get(mainWorktreePath)
+          : undefined
+
+      if (familySource !== undefined && familySource !== repo) {
+        continue
+      }
     }
 
     addToGroup(getGroupForRepository(repo), repo)
@@ -143,9 +375,13 @@ export function groupRepositories(
         group,
         repos,
         localRepositoryStateLookup,
-        groups
+        groups,
+        repositoryByPath,
+        familyWorktreesByMainPath,
+        showWorktreesInRepoList
       ),
     }))
+    .filter(group => group.items.length > 0)
 }
 
 // Returns the display title for a repository, which is either the alias
@@ -155,9 +391,12 @@ const getDisplayTitle = (r: Repositoryish) =>
 
 const toSortedListItems = (
   group: RepositoryListGroup,
-  repositories: ReadonlyArray<Repositoryish>,
+  repositories: ReadonlyArray<RepoGroupEntry>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  groups: Map<string, RepoGroupItem>
+  groups: Map<string, RepoGroupItem>,
+  repositoryByPath: ReadonlyMap<string, Repository>,
+  familyWorktreesByMainPath: ReadonlyMap<string, ReadonlyArray<WorktreeEntry>>,
+  showWorktreesInRepoList: boolean
 ): IRepositoryListItem[] => {
   const groupNames = new Map<string, number>()
   const allNames = new Map<string, number>()
@@ -169,7 +408,9 @@ const toSortedListItems = (
       continue
     }
 
-    for (const title of groupItem.repos.map(getDisplayTitle)) {
+    for (const title of groupItem.repos.map(entry =>
+      getDisplayTitle(entry.repository)
+    )) {
       allNames.set(title, (allNames.get(title) ?? 0) + 1)
       if (groupItem.group === group) {
         groupNames.set(title, (groupNames.get(title) ?? 0) + 1)
@@ -177,90 +418,402 @@ const toSortedListItems = (
     }
   }
 
-  return repositories
-    .map(r => {
-      const repoState = localRepositoryStateLookup.get(r.id)
-      const title = getDisplayTitle(r)
+  const rows = repositories.map(({ repository: r, recentPath }) => {
+    const repoState = localRepositoryStateLookup.get(r.id)
+    const title = getDisplayTitle(r)
 
-      const needsDisambiguation =
-        // If the repository is in the enterprise group and has a duplicate
-        // name in the group, we need to disambiguate it. We don't have to
-        // disambiguate repositories in the 'dotcom' group because they are
-        // already grouped by owner. If the repository is in the 'recent'
-        // group and has a duplicate name in any group, we need to
-        // disambiguate it.
-        ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
-        ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent')
+    const needsDisambiguation =
+      // If the repository is in the enterprise group and has a duplicate
+      // name in the group, we need to disambiguate it. We don't have to
+      // disambiguate repositories in the 'dotcom' group because they are
+      // already grouped by owner. If the repository is in the 'recent'
+      // group and has a duplicate name in any group, we need to
+      // disambiguate it.
+      ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
+      ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent')
 
-      return buildRepositoryRows(r, repoState, needsDisambiguation)
-    })
-    .sort((x, y) =>
-      caseInsensitiveCompare(
-        getDisplayTitle(x[0].repository),
-        getDisplayTitle(y[0].repository)
-      )
-    )
-    .flat()
+    return group.kind === 'recent'
+      ? buildRecentRepositoryRows(
+          r,
+          repoState,
+          needsDisambiguation,
+          repositoryByPath,
+          localRepositoryStateLookup,
+          familyWorktreesByMainPath,
+          showWorktreesInRepoList,
+          recentPath
+        )
+      : buildRepositoryRows(
+          r,
+          repoState,
+          needsDisambiguation,
+          repositoryByPath,
+          localRepositoryStateLookup,
+          familyWorktreesByMainPath,
+          showWorktreesInRepoList
+        )
+  })
+
+  const flattenedRows =
+    group.kind === 'recent'
+      ? rows.flat()
+      : rows
+          .sort((x, y) => caseInsensitiveCompare(x[0].title, y[0].title))
+          .flat()
+
+  return group.kind === 'recent'
+    ? withWorktreeBranchNameDisambiguation(flattenedRows)
+    : flattenedRows
 }
 
 const shortBranchName = (branch: string | null): string | null =>
   branch ? branch.replace(/^refs\/heads\//, '') : null
 
+const getSearchableParentDirectory = (path: string): string | null => {
+  const parent = Path.basename(Path.dirname(path))
+  const normalizedParent = parent.toLowerCase()
+
+  // Keep meaningful parent directories searchable so same-name worktrees can
+  // be distinguished by path, but ignore generic worktree containers. Those
+  // containers would make short queries match unrelated worktree rows.
+  return normalizedParent === 'worktrees' || normalizedParent === '.worktrees'
+    ? null
+    : parent
+}
+
+const getWorktreeSearchText = (
+  title: string,
+  repository: Repository,
+  worktree: WorktreeEntry,
+  mainWorktree: WorktreeEntry
+): ReadonlyArray<string> => {
+  const searchTerms = [
+    nameOf(repository),
+    Path.basename(worktree.path),
+    shortBranchName(worktree.branch),
+    Path.basename(mainWorktree.path),
+    getSearchableParentDirectory(worktree.path),
+  ].filter((text): text is string => text !== null && text.length > 0)
+
+  return [title, Array.from(new Set(searchTerms)).join(' ')]
+}
+
 /**
  * Builds the list rows for a single repository: the repository row itself
  * (representing the main worktree) followed by one row per linked worktree.
  */
-function buildRepositoryRows(
+const buildPlainRepositoryRow = (
   r: Repositoryish,
   repoState: ILocalRepositoryState | undefined,
   needsDisambiguation: boolean
-): IRepositoryListItem[] {
+): IRepositoryListItem => {
   const title = getDisplayTitle(r)
+
+  return {
+    text: r instanceof Repository ? [title, nameOf(r)] : [title],
+    id: r.id.toString(),
+    title,
+    repository: r,
+    needsDisambiguation,
+    aheadBehind: repoState?.aheadBehind ?? null,
+    changedFilesCount: repoState?.changedFilesCount ?? 0,
+    branchName: repoState?.branchName ?? null,
+    defaultBranchName: repoState?.defaultBranchName ?? null,
+    needsBranchNameDisambiguation: false,
+    worktreePathDisambiguation: null,
+    isNestedWorktree: false,
+    isPrunableWorktree: false,
+    isSyntheticWorktreeRoot: false,
+    sourceRepository: null,
+    familyMainPath: null,
+    worktree: null,
+  }
+}
+
+const findWorktreeFamilyForRepository = (
+  repository: Repository,
+  repoState: ILocalRepositoryState | undefined,
+  familyWorktreesByMainPath: ReadonlyMap<string, ReadonlyArray<WorktreeEntry>>,
+  targetPath: string
+): ReadonlyArray<WorktreeEntry> => {
+  const normalizedTargetPath = normalizePath(targetPath)
+  const repoWorktrees = repoState?.worktrees ?? []
+  const repoMainWorktree = getMainWorktree(repoWorktrees)
+
+  if (repoMainWorktree !== null) {
+    const family = familyWorktreesByMainPath.get(
+      normalizePath(repoMainWorktree.path)
+    )
+
+    if (family !== undefined) {
+      return family
+    }
+  }
+
+  const directFamily = familyWorktreesByMainPath.get(normalizedTargetPath)
+  if (directFamily !== undefined) {
+    return directFamily
+  }
+
+  if (
+    repoWorktrees.some(wt => normalizePath(wt.path) === normalizedTargetPath)
+  ) {
+    return repoWorktrees
+  }
+
+  for (const family of familyWorktreesByMainPath.values()) {
+    if (family.some(wt => normalizePath(wt.path) === normalizedTargetPath)) {
+      return family
+    }
+  }
+
+  return repoWorktrees
+}
+
+const buildRecentRepositoryRows = (
+  r: Repositoryish,
+  repoState: ILocalRepositoryState | undefined,
+  needsDisambiguation: boolean,
+  repositoryByPath: ReadonlyMap<string, Repository>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
+  familyWorktreesByMainPath: ReadonlyMap<string, ReadonlyArray<WorktreeEntry>>,
+  showWorktreesInRepoList: boolean,
+  recentPath: string | null
+): IRepositoryListItem[] => {
+  if (!(r instanceof Repository) || !showWorktreesInRepoList) {
+    return [buildPlainRepositoryRow(r, repoState, needsDisambiguation)]
+  }
+
+  const repositoryPath = normalizePath(r.path)
+  const targetPath = normalizePath(recentPath ?? r.path)
+  const worktrees = findWorktreeFamilyForRepository(
+    r,
+    repoState,
+    familyWorktreesByMainPath,
+    targetPath
+  )
+  const mainWorktree = getMainWorktree(worktrees)
+  const worktree = worktrees.find(wt => normalizePath(wt.path) === targetPath)
+
+  if (mainWorktree === null || worktree === undefined) {
+    return [buildPlainRepositoryRow(r, repoState, needsDisambiguation)]
+  }
+
+  const worktreePath = normalizePath(worktree.path)
+  const mainWorktreePath = normalizePath(mainWorktree.path)
+  const mainRepository = repositoryByPath.get(mainWorktreePath)
+  const rowRepository = repositoryByPath.get(worktreePath) ?? r
+  const rowRepositoryState = localRepositoryStateLookup.get(rowRepository.id)
+  const rowRepositoryMatchesWorktree =
+    normalizePath(rowRepository.path) === worktreePath
+  const title = getWorktreeDisplayTitle(rowRepository, worktree)
+  const sourceIsRowWorktree = repositoryPath === worktreePath
+
+  return [
+    {
+      text: getWorktreeSearchText(title, rowRepository, worktree, mainWorktree),
+      id:
+        worktree.type === 'main' && mainRepository !== undefined
+          ? mainRepository.id.toString()
+          : `${rowRepository.id}:${worktreePath}`,
+      title,
+      repository: rowRepository,
+      needsDisambiguation,
+      aheadBehind: rowRepositoryMatchesWorktree
+        ? rowRepositoryState?.aheadBehind ??
+          (sourceIsRowWorktree ? repoState?.aheadBehind ?? null : null)
+        : null,
+      changedFilesCount: rowRepositoryMatchesWorktree
+        ? rowRepositoryState?.changedFilesCount ??
+          (sourceIsRowWorktree ? repoState?.changedFilesCount ?? 0 : 0)
+        : 0,
+      branchName: shortBranchName(worktree.branch),
+      defaultBranchName:
+        rowRepositoryState?.defaultBranchName ??
+        repoState?.defaultBranchName ??
+        null,
+      needsBranchNameDisambiguation: false,
+      worktreePathDisambiguation: null,
+      isNestedWorktree: worktree.type === 'linked',
+      isPrunableWorktree: worktree.isPrunable,
+      isSyntheticWorktreeRoot: false,
+      sourceRepository:
+        worktree.type === 'linked'
+          ? mainRepository ?? r
+          : mainRepository === undefined
+          ? r
+          : null,
+      familyMainPath: mainWorktreePath,
+      worktree,
+    },
+  ]
+}
+
+function buildRepositoryRows(
+  r: Repositoryish,
+  repoState: ILocalRepositoryState | undefined,
+  needsDisambiguation: boolean,
+  repositoryByPath: ReadonlyMap<string, Repository>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
+  familyWorktreesByMainPath: ReadonlyMap<string, ReadonlyArray<WorktreeEntry>>,
+  showWorktreesInRepoList: boolean
+): IRepositoryListItem[] {
   const defaultBranchName = repoState?.defaultBranchName ?? null
 
-  const worktrees = r instanceof Repository ? repoState?.worktrees ?? [] : []
-  const mainWorktree = worktrees.find(wt => wt.type === 'main') ?? null
+  const sourceRepositoryPath =
+    r instanceof Repository ? normalizePath(r.path) : null
+  const repoWorktrees = repoState?.worktrees ?? []
+  const repoFamilyMainPath = getMainWorktree(repoWorktrees)?.path
+  const familyWorktrees =
+    repoFamilyMainPath !== undefined
+      ? familyWorktreesByMainPath.get(normalizePath(repoFamilyMainPath))
+      : sourceRepositoryPath !== null
+      ? familyWorktreesByMainPath.get(sourceRepositoryPath)
+      : undefined
+  const worktrees =
+    r instanceof Repository && showWorktreesInRepoList
+      ? familyWorktrees ?? repoWorktrees
+      : []
+  const mainWorktree = getMainWorktree(worktrees)
+
+  if (!(r instanceof Repository) || mainWorktree === null) {
+    return [buildPlainRepositoryRow(r, repoState, needsDisambiguation)]
+  }
+
+  const mainWorktreePath = normalizePath(mainWorktree.path)
+  const mainRepository = repositoryByPath.get(mainWorktreePath)
 
   const aheadBehind = repoState?.aheadBehind ?? null
   const changedFilesCount = repoState?.changedFilesCount ?? 0
-  const isMainWorktreeActive =
-    mainWorktree === null || mainWorktree.path === r.path
-  const mainWorktreeText =
-    r instanceof Repository ? [title, nameOf(r)] : [title]
+  const mainRepositoryState =
+    mainRepository !== undefined
+      ? localRepositoryStateLookup.get(mainRepository.id)
+      : undefined
+  const mainRowRepository = mainRepository ?? r
+  const mainTitle =
+    mainRepository !== undefined
+      ? getWorktreeDisplayTitle(mainRepository, mainWorktree)
+      : Path.basename(mainWorktree.path)
+  const sourceIsMainWorktree = sourceRepositoryPath === mainWorktreePath
 
   const mainWorktreeRow: IRepositoryListItem = {
-    text: mainWorktreeText,
-    id: r.id.toString(),
-    repository: r,
+    text: getWorktreeSearchText(
+      mainTitle,
+      mainRowRepository,
+      mainWorktree,
+      mainWorktree
+    ),
+    id:
+      mainRepository !== undefined
+        ? mainRepository.id.toString()
+        : `${r.id}:${mainWorktreePath}`,
+    title: mainTitle,
+    repository: mainRowRepository,
     needsDisambiguation,
-    aheadBehind: isMainWorktreeActive ? aheadBehind : null,
-    changedFilesCount: isMainWorktreeActive ? changedFilesCount : 0,
-    branchName: mainWorktree
-      ? shortBranchName(mainWorktree.branch)
-      : repoState?.branchName ?? null,
-    defaultBranchName,
+    aheadBehind:
+      mainRepositoryState?.aheadBehind ??
+      (sourceIsMainWorktree ? aheadBehind : null),
+    changedFilesCount:
+      mainRepositoryState?.changedFilesCount ??
+      (sourceIsMainWorktree ? changedFilesCount : 0),
+    branchName: shortBranchName(mainWorktree.branch),
+    defaultBranchName:
+      mainRepositoryState?.defaultBranchName ?? defaultBranchName,
+    needsBranchNameDisambiguation: false,
+    worktreePathDisambiguation: null,
+    isNestedWorktree: false,
+    isPrunableWorktree: mainWorktree.isPrunable,
+    isSyntheticWorktreeRoot: mainRepository === undefined,
+    sourceRepository: mainRepository === undefined ? r : null,
+    familyMainPath: mainWorktreePath,
     worktree: mainWorktree,
   }
 
-  // Linked worktree rows match the same filter text as their repository so they travel with it
   const linkedWorktreeRows = worktrees
     .filter(wt => wt.type === 'linked')
+    .sort(
+      (x, y) =>
+        caseInsensitiveCompare(Path.basename(x.path), Path.basename(y.path)) ||
+        caseInsensitiveCompare(x.path, y.path)
+    )
     .map((wt): IRepositoryListItem => {
-      const isActiveWorktree = wt.path === r.path
+      const worktreePath = normalizePath(wt.path)
+      const rowRepository = repositoryByPath.get(worktreePath) ?? r
+      const rowRepositoryState = localRepositoryStateLookup.get(
+        rowRepository.id
+      )
+      const linkedTitle = getWorktreeDisplayTitle(rowRepository, wt)
+      const rowRepositoryMatchesWorktree =
+        normalizePath(rowRepository.path) === worktreePath
+      const sourceIsRowWorktree = sourceRepositoryPath === worktreePath
+
       return {
-        text: [Path.basename(wt.path)],
-        id: `${r.id}:${wt.path}`,
-        repository: r,
+        text: getWorktreeSearchText(
+          linkedTitle,
+          rowRepository,
+          wt,
+          mainWorktree
+        ),
+        id: `${rowRepository.id}:${worktreePath}`,
+        title: linkedTitle,
+        repository: rowRepository,
         needsDisambiguation: false,
-        aheadBehind: isActiveWorktree ? aheadBehind : null,
-        changedFilesCount: isActiveWorktree ? changedFilesCount : 0,
+        aheadBehind: rowRepositoryMatchesWorktree
+          ? rowRepositoryState?.aheadBehind ??
+            (sourceIsRowWorktree ? aheadBehind : null)
+          : null,
+        changedFilesCount: rowRepositoryMatchesWorktree
+          ? rowRepositoryState?.changedFilesCount ??
+            (sourceIsRowWorktree ? changedFilesCount : 0)
+          : 0,
         branchName: shortBranchName(wt.branch),
-        defaultBranchName,
+        defaultBranchName:
+          rowRepositoryState?.defaultBranchName ?? defaultBranchName,
+        needsBranchNameDisambiguation: false,
+        worktreePathDisambiguation: null,
+        isNestedWorktree: true,
+        isPrunableWorktree: wt.isPrunable,
+        isSyntheticWorktreeRoot: false,
+        sourceRepository: r,
+        familyMainPath: mainWorktreePath,
         worktree: wt,
       }
     })
 
-  return [mainWorktreeRow, ...linkedWorktreeRows]
+  return withWorktreeBranchNameDisambiguation([
+    mainWorktreeRow,
+    ...linkedWorktreeRows,
+  ])
+}
+
+const withWorktreeBranchNameDisambiguation = (
+  rows: ReadonlyArray<IRepositoryListItem>
+): IRepositoryListItem[] => {
+  const worktreeTitleCounts = new Map<string, number>()
+
+  for (const row of rows) {
+    if (row.worktree === null) {
+      continue
+    }
+
+    worktreeTitleCounts.set(
+      row.title,
+      (worktreeTitleCounts.get(row.title) ?? 0) + 1
+    )
+  }
+
+  return rows.map(row => {
+    const needsWorktreeDisambiguation =
+      row.worktree !== null && (worktreeTitleCounts.get(row.title) ?? 0) > 1
+
+    return {
+      ...row,
+      needsBranchNameDisambiguation: needsWorktreeDisambiguation,
+      worktreePathDisambiguation: needsWorktreeDisambiguation
+        ? Path.dirname(row.worktree.path)
+        : null,
+    }
+  })
 }
 
 /**
@@ -277,27 +830,92 @@ export function buildPinnedGroup(
     return null
   }
 
-  const idToItems = new Map<number, IRepositoryListItem[]>()
+  const pinnedIdSet = new Set(pinnedIds)
+  const idToFamilyKey = new Map<number, string>()
+  const familyItems = new Map<string, IRepositoryListItem[]>()
+  const idItems = new Map<number, IRepositoryListItem[]>()
   const completedIds = new Set<number>()
+  const completedFamilyKeys = new Set<string>()
+
   for (const group of allGroups) {
+    const groupIds = new Set<number>()
+    const groupFamilyKeys = new Set<string>()
+
     for (const item of group.items) {
       const id = item.repository.id
-      if (id <= 0 || completedIds.has(id)) {
-        continue
+      const familyKey = item.familyMainPath
+
+      if (pinnedIdSet.has(id) && familyKey !== null) {
+        idToFamilyKey.set(id, familyKey)
       }
-      const rows = idToItems.get(id)
-      if (rows === undefined) {
-        idToItems.set(id, [item])
+
+      if (familyKey !== null) {
+        if (completedFamilyKeys.has(familyKey)) {
+          continue
+        }
+
+        const items = familyItems.get(familyKey)
+        if (items === undefined) {
+          familyItems.set(familyKey, [item])
+        } else {
+          items.push(item)
+        }
+
+        groupFamilyKeys.add(familyKey)
       } else {
-        rows.push(item)
+        if (id <= 0 || completedIds.has(id)) {
+          continue
+        }
+
+        groupIds.add(id)
+
+        const items = idItems.get(id)
+        if (items === undefined) {
+          idItems.set(id, [item])
+        } else {
+          items.push(item)
+        }
       }
     }
-    for (const id of idToItems.keys()) {
+
+    for (const id of groupIds) {
       completedIds.add(id)
+    }
+
+    for (const familyKey of groupFamilyKeys) {
+      completedFamilyKeys.add(familyKey)
     }
   }
 
-  const items = pinnedIds.flatMap(id => idToItems.get(id) ?? [])
+  const items: IRepositoryListItem[] = []
+  const emittedIds = new Set<number>()
+  const emittedFamilyKeys = new Set<string>()
+  for (const id of pinnedIds) {
+    const familyKey = idToFamilyKey.get(id)
+    if (familyKey !== undefined) {
+      if (emittedFamilyKeys.has(familyKey)) {
+        continue
+      }
+
+      const family = familyItems.get(familyKey)
+      if (family !== undefined) {
+        items.push(...family)
+        emittedFamilyKeys.add(familyKey)
+      }
+
+      continue
+    }
+
+    if (emittedIds.has(id)) {
+      continue
+    }
+
+    const pinnedItems = idItems.get(id)
+    if (pinnedItems !== undefined) {
+      items.push(...pinnedItems)
+      emittedIds.add(id)
+    }
+  }
 
   if (items.length === 0) {
     return null
@@ -320,10 +938,24 @@ export function filterPinnedFromGroups(
   }
 
   const pinnedIdSet = new Set(pinnedIds)
+  const pinnedFamilyKeys = new Set<string>()
+  for (const group of groups) {
+    for (const item of group.items) {
+      if (pinnedIdSet.has(item.repository.id) && item.familyMainPath !== null) {
+        pinnedFamilyKeys.add(item.familyMainPath)
+      }
+    }
+  }
+
   return groups
     .map(group => ({
       ...group,
-      items: group.items.filter(item => !pinnedIdSet.has(item.repository.id)),
+      items: group.items.filter(
+        item =>
+          !pinnedIdSet.has(item.repository.id) &&
+          (item.familyMainPath === null ||
+            !pinnedFamilyKeys.has(item.familyMainPath))
+      ),
     }))
     .filter(group => group.items.length > 0)
 }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -5,6 +5,7 @@ import {
   groupRepositories,
   buildPinnedGroup,
   filterPinnedFromGroups,
+  isRepositoryListItemPinned,
   IRepositoryListItem,
   Repositoryish,
   RepositoryListGroup,
@@ -20,6 +21,7 @@ import { IMatch, IMatches } from '../../lib/fuzzy-find'
 import { ILocalRepositoryState, Repository } from '../../models/repository'
 import { normalizePath } from '../../lib/helpers/path'
 import { FoldoutType } from '../../lib/app-state'
+import type { IRecentRepositorySelection } from '../../lib/app-state'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { Octicon, syncClockwise } from '../octicons'
@@ -31,8 +33,10 @@ import { encodePathAsUrl } from '../../lib/path'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import memoizeOne from 'memoize-one'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
+import { pruneWorktrees } from '../../lib/git/worktree'
 import {
   generateRepositoryListContextMenu,
+  generateSyntheticWorktreeRootContextMenu,
   generateWorktreeListItemContextMenu,
 } from '../repositories-list/repository-list-item-context-menu'
 import { openWorktreeInNewWindow } from '../main-process-proxy'
@@ -49,7 +53,7 @@ interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly showRecentRepositories: boolean
-  readonly recentRepositories: ReadonlyArray<number>
+  readonly recentRepositories: ReadonlyArray<IRecentRepositorySelection>
 
   /** A cache of the latest repository state values, keyed by the repository id */
   readonly localRepositoryStateLookup: ReadonlyMap<
@@ -117,6 +121,83 @@ interface IRepositoriesListState {
 
 const RowHeight = 29
 
+export function shouldShowRepositoryListBranchName(
+  item: Pick<
+    IRepositoryListItem,
+    'branchName' | 'defaultBranchName' | 'needsBranchNameDisambiguation'
+  >,
+  showBranchNameInRepoList: ShowBranchNameInRepoListSetting
+): boolean {
+  if (item.needsBranchNameDisambiguation && item.branchName !== null) {
+    return true
+  }
+
+  switch (showBranchNameInRepoList) {
+    case ShowBranchNameInRepoListSetting.Never:
+      return false
+    case ShowBranchNameInRepoListSetting.Always:
+      return true
+    case ShowBranchNameInRepoListSetting.WhenNotDefault:
+      return item.branchName !== item.defaultBranchName
+    default:
+      assertNever(
+        showBranchNameInRepoList,
+        `Unknown show branch name setting: ${showBranchNameInRepoList}`
+      )
+  }
+}
+
+export function getWorktreeFamilyMainPath(
+  repository: Repository,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+): string | null {
+  const repositoryPath = normalizePath(repository.path)
+  const directState = localRepositoryStateLookup.get(repository.id)
+  const directMainWorktree = directState?.worktrees.find(
+    wt => wt.type === 'main'
+  )
+
+  if (directMainWorktree !== undefined) {
+    return normalizePath(directMainWorktree.path)
+  }
+
+  for (const state of localRepositoryStateLookup.values()) {
+    const stateMainWorktree = state.worktrees.find(wt => wt.type === 'main')
+    if (stateMainWorktree === undefined) {
+      continue
+    }
+
+    if (state.worktrees.some(wt => normalizePath(wt.path) === repositoryPath)) {
+      return normalizePath(stateMainWorktree.path)
+    }
+  }
+
+  return null
+}
+
+export function getWorktreeFamilyRepositories(
+  repository: Repository,
+  repositories: ReadonlyArray<Repositoryish>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+): ReadonlyArray<Repository> {
+  const mainWorktreePath = getWorktreeFamilyMainPath(
+    repository,
+    localRepositoryStateLookup
+  )
+  if (mainWorktreePath === null) {
+    return [repository]
+  }
+
+  const family = repositories.filter(
+    (candidate): candidate is Repository =>
+      candidate instanceof Repository &&
+      getWorktreeFamilyMainPath(candidate, localRepositoryStateLookup) ===
+        mainWorktreePath
+  )
+
+  return family.length > 0 ? family : [repository]
+}
+
 /**
  * Iterate over all groups until a list item is found that matches
  * the id of the provided repository.
@@ -168,14 +249,16 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<IRecentRepositorySelection>,
+      showWorktreesInRepoList: boolean
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            { showWorktreesInRepoList }
           )
   )
 
@@ -202,20 +285,10 @@ export class RepositoriesList extends React.Component<
   }
 
   private shouldShowBranchName(item: IRepositoryListItem): boolean {
-    const { showBranchNameInRepoList } = this.props
-    switch (showBranchNameInRepoList) {
-      case ShowBranchNameInRepoListSetting.Never:
-        return false
-      case ShowBranchNameInRepoListSetting.Always:
-        return true
-      case ShowBranchNameInRepoListSetting.WhenNotDefault:
-        return item.branchName !== item.defaultBranchName
-      default:
-        assertNever(
-          showBranchNameInRepoList,
-          `Unknown show branch name setting: ${showBranchNameInRepoList}`
-        )
-    }
+    return shouldShowRepositoryListBranchName(
+      item,
+      this.props.showBranchNameInRepoList
+    )
   }
 
   private renderItem = (item: IRepositoryListItem, matches: IMatches) => {
@@ -224,11 +297,15 @@ export class RepositoriesList extends React.Component<
       <RepositoryListItem
         key={item.id}
         repository={repository}
+        title={item.title}
         needsDisambiguation={item.needsDisambiguation}
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
         branchName={this.shouldShowBranchName(item) ? item.branchName : null}
+        worktreePathDisambiguation={item.worktreePathDisambiguation}
+        isNestedWorktree={item.isNestedWorktree}
+        isPrunableWorktree={item.isPrunableWorktree}
         worktree={item.worktree}
       />
     )
@@ -268,6 +345,10 @@ export class RepositoriesList extends React.Component<
     const uncommittedChangesTooltip = hasChanges
       ? `There are uncommitted changes in this repository.`
       : null
+    const prunableWorktreeTooltip = item.isPrunableWorktree
+      ? 'This worktree entry is stale and should be pruned.'
+      : null
+    const path = item.worktree?.path ?? repository.path
 
     const ahead = aheadBehind?.ahead ?? 0
     const behind = aheadBehind?.behind ?? 0
@@ -281,7 +362,7 @@ export class RepositoriesList extends React.Component<
         </div>
         <div>
           <div className="label">Path: </div>
-          {repository.path}
+          {path}
         </div>
         {branchName && (
           <div>
@@ -308,6 +389,16 @@ export class RepositoriesList extends React.Component<
               </span>
             </div>
             {uncommittedChangesTooltip}
+          </div>
+        )}
+        {prunableWorktreeTooltip && (
+          <div>
+            <div className="label">
+              <span className="prunable-indicator-wrapper">
+                <Octicon symbol={octicons.alert} />
+              </span>
+            </div>
+            {prunableWorktreeTooltip}
           </div>
         )}
       </div>
@@ -353,6 +444,22 @@ export class RepositoriesList extends React.Component<
   }
 
   private onItemClick = (item: IRepositoryListItem) => {
+    if (
+      item.isSyntheticWorktreeRoot &&
+      (item.worktree === null || item.sourceRepository === null)
+    ) {
+      return
+    }
+
+    if (item.isPrunableWorktree) {
+      void this.props.dispatcher.postError(
+        new Error(
+          'This worktree entry is stale. Use the context menu to prune stale worktrees.'
+        )
+      )
+      return
+    }
+
     const hasIndicator =
       item.changedFilesCount > 0 ||
       (item.aheadBehind !== null
@@ -363,13 +470,21 @@ export class RepositoriesList extends React.Component<
     // Each row maps to a specific worktree. Clicking a row switches to
     // its worktree, unless the row is already the checked-out one.
     // Switching worktrees already selects the corresponding repository
+    const worktreeSwitchRepository =
+      item.sourceRepository ??
+      (item.repository instanceof Repository ? item.repository : null)
+
     if (
       item.worktree !== null &&
-      item.repository instanceof Repository &&
-      normalizePath(item.worktree.path) !== normalizePath(item.repository.path)
+      worktreeSwitchRepository !== null &&
+      normalizePath(item.worktree.path) !==
+        normalizePath(worktreeSwitchRepository.path)
     ) {
       this.props.dispatcher.closeFoldout(FoldoutType.Repository)
-      this.props.dispatcher.switchWorktree(item.repository, item.worktree)
+      this.props.dispatcher.switchWorktree(
+        worktreeSwitchRepository,
+        item.worktree
+      )
       return
     }
 
@@ -382,9 +497,33 @@ export class RepositoriesList extends React.Component<
   ) => {
     event.preventDefault()
 
+    if (item.isSyntheticWorktreeRoot && item.worktree !== null) {
+      const isPinned = isRepositoryListItemPinned(
+        item,
+        this.state.pinnedRepositoriesIds,
+        this.props.repositories,
+        this.props.localRepositoryStateLookup
+      )
+
+      showContextualMenu(
+        generateSyntheticWorktreeRootContextMenu({
+          name: item.title,
+          path: item.worktree.path,
+          sourceRepository: item.sourceRepository,
+          isPinned,
+          onCopyRepoPath: path =>
+            this.props.dispatcher.copyPathToClipboard(path),
+          onPinRepository: this.onPinRepository,
+          onUnpinRepository: this.onUnpinRepository,
+        })
+      )
+      return
+    }
+
     if (
       item.worktree !== null &&
       item.worktree.type === 'linked' &&
+      item.isNestedWorktree &&
       item.repository instanceof Repository
     ) {
       showContextualMenu(
@@ -396,6 +535,9 @@ export class RepositoriesList extends React.Component<
           onCreateWorktree: this.onCreateWorktree,
           onRenameWorktree: this.onRenameWorktree,
           onDeleteWorktree: this.onDeleteWorktree,
+          onPruneStaleWorktrees: () => {
+            this.onPruneStaleWorktrees(item)
+          },
           onViewOnGitHub: this.props.onViewOnGitHub,
           onOpenWorktreeInNewWindow: this.onOpenWorktreeInNewWindow,
           onOpenInShell: this.props.onOpenInShell,
@@ -408,9 +550,12 @@ export class RepositoriesList extends React.Component<
       return
     }
 
-    const isPinned =
-      item.repository instanceof Repository &&
-      this.state.pinnedRepositoriesIds.includes(item.repository.id)
+    const isPinned = isRepositoryListItemPinned(
+      item,
+      this.state.pinnedRepositoriesIds,
+      this.props.repositories,
+      this.props.localRepositoryStateLookup
+    )
 
     const items = generateRepositoryListContextMenu({
       worktreePath: item.worktree?.path,
@@ -451,7 +596,32 @@ export class RepositoriesList extends React.Component<
     showContextualMenu(items)
   }
 
-  private getItemAriaLabel = (item: IRepositoryListItem) => item.repository.name
+  private onPruneStaleWorktrees = async (item: IRepositoryListItem) => {
+    const repository =
+      item.sourceRepository ??
+      (item.repository instanceof Repository ? item.repository : null)
+
+    if (repository === null) {
+      return
+    }
+
+    try {
+      await pruneWorktrees(repository)
+      await Promise.all(
+        getWorktreeFamilyRepositories(
+          repository,
+          this.props.repositories,
+          this.props.localRepositoryStateLookup
+        ).map(familyRepository =>
+          this.props.dispatcher.refreshRepository(familyRepository)
+        )
+      )
+    } catch (error) {
+      this.props.dispatcher.postError(error)
+    }
+  }
+
+  private getItemAriaLabel = (item: IRepositoryListItem) => item.title
   private getGroupAriaLabelGetter =
     (
       groups: ReadonlyArray<
@@ -465,7 +635,8 @@ export class RepositoriesList extends React.Component<
     let groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.showWorktreesInRepoList
     )
 
     if (!this.props.showRecentRepositories) {
@@ -499,6 +670,7 @@ export class RepositoriesList extends React.Component<
           selectedItem={selectedItem}
           filterText={this.props.filterText}
           onFilterTextChanged={this.props.onFilterTextChanged}
+          preserveItemOrderWhenFiltering={true}
           renderItem={this.renderItem}
           renderRowFocusTooltip={this.renderRowFocusTooltip}
           renderGroupHeader={this.renderGroupHeader}
@@ -780,7 +952,18 @@ export class RepositoriesList extends React.Component<
   }
 
   private onUnpinRepository = (repository: Repository) => {
-    removePinnedRepository(repository)
+    const repositoriesToUnpin = this.props.showWorktreesInRepoList
+      ? getWorktreeFamilyRepositories(
+          repository,
+          this.props.repositories,
+          this.props.localRepositoryStateLookup
+        )
+      : [repository]
+
+    for (const familyRepository of repositoriesToUnpin) {
+      removePinnedRepository(familyRepository)
+    }
+
     this.setState({ pinnedRepositoriesIds: getPinnedRepositories() })
   }
 }

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -15,6 +15,7 @@ import {
   DefaultEditorLabel,
   DefaultShellLabel,
 } from '../lib/context-menu'
+import { normalizePath } from '../../lib/helpers/path'
 
 interface IRepositoryListItemContextMenuConfig {
   repository: Repositoryish
@@ -40,6 +41,56 @@ interface IRepositoryListItemContextMenuConfig {
   worktreePath?: string
 }
 
+interface ISyntheticWorktreeRootContextMenuConfig {
+  readonly name: string
+  readonly path: string
+  readonly sourceRepository: Repository | null
+  readonly isPinned: boolean
+  readonly onCopyRepoPath: (path: string) => void
+  readonly onPinRepository?: (repository: Repository) => void
+  readonly onUnpinRepository?: (repository: Repository) => void
+}
+
+export const generateSyntheticWorktreeRootContextMenu = (
+  config: ISyntheticWorktreeRootContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const pinItems =
+    config.sourceRepository === null
+      ? []
+      : buildPinMenuItems({
+          repository: config.sourceRepository,
+          shellLabel: undefined,
+          externalEditorLabel: undefined,
+          askForConfirmationOnRemoveRepository: false,
+          onViewOnGitHub: () => {},
+          onOpenInShell: () => {},
+          onShowRepository: () => {},
+          onOpenInExternalEditor: () => {},
+          onRemoveRepository: () => {},
+          onChangeRepositoryAlias: () => {},
+          onRemoveRepositoryAlias: () => {},
+          onChangeRepositoryGroupName: () => {},
+          onRemoveRepositoryGroupName: () => {},
+          onCopyRepoPath: config.onCopyRepoPath,
+          isPinned: config.isPinned,
+          onPinRepository: config.onPinRepository,
+          onUnpinRepository: config.onUnpinRepository,
+        })
+
+  return [
+    ...pinItems,
+    ...(pinItems.length > 0 ? [{ type: 'separator' as const }] : []),
+    {
+      label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
+      action: () => clipboard.writeText(config.name),
+    },
+    {
+      label: __DARWIN__ ? 'Copy Repo Path' : 'Copy repo path',
+      action: () => config.onCopyRepoPath(config.path),
+    },
+  ]
+}
+
 export const generateRepositoryListContextMenu = (
   config: IRepositoryListItemContextMenuConfig
 ) => {
@@ -58,6 +109,13 @@ export const generateRepositoryListContextMenu = (
   const openInShell = config.shellLabel
     ? `Open in ${config.shellLabel}`
     : DefaultShellLabel
+  const rowPath = config.worktreePath ?? repository.path
+  const rowPathIsRepositoryPath =
+    config.worktreePath === undefined ||
+    normalizePath(config.worktreePath) === normalizePath(repository.path)
+  const rowName = !rowPathIsRepositoryPath
+    ? Path.basename(rowPath)
+    : repository.name
 
   const items: ReadonlyArray<IMenuItem> = [
     ...buildAliasMenuItems(config),
@@ -67,11 +125,11 @@ export const generateRepositoryListContextMenu = (
     { type: 'separator' },
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
-      action: () => clipboard.writeText(repository.name),
+      action: () => clipboard.writeText(rowName),
     },
     {
       label: __DARWIN__ ? 'Copy Repo Path' : 'Copy repo path',
-      action: () => config.onCopyRepoPath(repository.path),
+      action: () => config.onCopyRepoPath(rowPath),
     },
     { type: 'separator' },
     {
@@ -126,6 +184,7 @@ interface IWorktreeListItemContextMenuConfig {
   onCreateWorktree: (repository: Repository) => void
   onRenameWorktree: (repository: Repository, worktreePath: string) => void
   onDeleteWorktree: (repository: Repository, worktreePath: string) => void
+  onPruneStaleWorktrees?: () => void
   onViewOnGitHub: (repository: Repositoryish) => void
   onOpenWorktreeInNewWindow: (
     repository: Repository,
@@ -145,7 +204,9 @@ export const generateWorktreeListItemContextMenu = (
   const name = Path.basename(path)
   const isGitHub = isRepositoryWithGitHubRepository(repository)
   const hasOriginUrl = hasDefaultRemoteUrl(repository)
-  const canModify = !worktree.isLocked
+  const canUseWorktreePath = !worktree.isPrunable
+  const canModify = !worktree.isLocked && canUseWorktreePath
+  const canDelete = canModify
   const openInExternalEditor = config.externalEditorLabel
     ? `Open in ${config.externalEditorLabel}`
     : DefaultEditorLabel
@@ -157,6 +218,7 @@ export const generateWorktreeListItemContextMenu = (
     {
       label: __DARWIN__ ? 'New Worktree…' : 'New worktree…',
       action: () => config.onCreateWorktree(repository),
+      enabled: canUseWorktreePath,
     },
     {
       label: __DARWIN__ ? 'Rename Worktree…' : 'Rename worktree…',
@@ -185,24 +247,39 @@ export const generateWorktreeListItemContextMenu = (
         ? 'Open Worktree in New Window'
         : 'Open worktree in new window',
       action: () => config.onOpenWorktreeInNewWindow(repository, path),
+      enabled: canUseWorktreePath,
     },
     {
       label: openInShell,
       action: () => config.onOpenInShell(repository, path),
+      enabled: canUseWorktreePath,
     },
     {
       label: RevealInFileManagerLabel,
       action: () => config.onShowRepository(repository, path),
+      enabled: canUseWorktreePath,
     },
     {
       label: openInExternalEditor,
       action: () => config.onOpenInExternalEditor(repository, path),
+      enabled: canUseWorktreePath,
     },
+    ...(worktree.isPrunable && config.onPruneStaleWorktrees !== undefined
+      ? [
+          { type: 'separator' as const },
+          {
+            label: __DARWIN__
+              ? 'Prune Stale Worktrees'
+              : 'Prune stale worktrees',
+            action: config.onPruneStaleWorktrees,
+          },
+        ]
+      : []),
     { type: 'separator' },
     {
       label: __DARWIN__ ? 'Delete Worktree…' : 'Delete worktree…',
       action: () => config.onDeleteWorktree(repository, path),
-      enabled: canModify,
+      enabled: canDelete,
     },
   ]
 }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as Path from 'path'
 
 import { Repository } from '../../models/repository'
 import { Octicon, iconForRepository } from '../octicons'
@@ -18,6 +17,9 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
 
+  /** The repository or worktree name to display in the list. */
+  readonly title: string
+
   /** Does the repository need to be disambiguated in the list? */
   readonly needsDisambiguation: boolean
 
@@ -32,6 +34,15 @@ interface IRepositoryListItemProps {
 
   /** The name of the current branch, if it should be displayed */
   readonly branchName: string | null
+
+  /** Parent path to show when duplicate worktree names need visible disambiguation. */
+  readonly worktreePathDisambiguation: string | null
+
+  /** Whether this row is rendered nested below a main worktree row. */
+  readonly isNestedWorktree: boolean
+
+  /** Whether this row represents a stale worktree entry that Git can prune. */
+  readonly isPrunableWorktree: boolean
 
   /**
    * When set to a linked worktree, this row renders as a worktree nested below
@@ -54,6 +65,14 @@ function renderBranchNameBadge(branchName: string | null) {
   )
 }
 
+function renderWorktreePathDisambiguation(path: string | null) {
+  if (!path) {
+    return null
+  }
+
+  return <span className="worktree-path-disambiguation">{path}</span>
+}
+
 /** A repository item. */
 export class RepositoryListItem extends React.Component<
   IRepositoryListItemProps,
@@ -62,8 +81,8 @@ export class RepositoryListItem extends React.Component<
   private readonly listItemRef = createObservableRef<HTMLDivElement>()
 
   public render() {
-    const { worktree } = this.props
-    return worktree !== null && worktree.type === 'linked'
+    const { isNestedWorktree, worktree } = this.props
+    return isNestedWorktree && worktree !== null && worktree.type === 'linked'
       ? this.renderWorktree(worktree)
       : this.renderRepository()
   }
@@ -83,7 +102,7 @@ export class RepositoryListItem extends React.Component<
     }
 
     const classNameList = classNames('name', {
-      alias: alias !== null,
+      alias: alias !== null && this.props.title === alias,
     })
 
     return (
@@ -103,12 +122,16 @@ export class RepositoryListItem extends React.Component<
         <div className={classNames(classNameList)}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
           <HighlightText
-            text={alias ?? repository.name}
+            text={this.props.title}
             highlight={this.props.matches.title}
           />
         </div>
 
         {renderBranchNameBadge(this.props.branchName)}
+        {renderWorktreePathDisambiguation(
+          this.props.worktreePathDisambiguation
+        )}
+        {this.props.isPrunableWorktree && renderPrunableIndicator()}
 
         {repository instanceof Repository &&
           renderRepoIndicators({
@@ -139,12 +162,16 @@ export class RepositoryListItem extends React.Component<
 
         <div className="name">
           <HighlightText
-            text={Path.basename(worktree.path)}
+            text={this.props.title}
             highlight={this.props.matches.title}
           />
         </div>
 
         {renderBranchNameBadge(this.props.branchName)}
+        {renderWorktreePathDisambiguation(
+          this.props.worktreePathDisambiguation
+        )}
+        {this.props.isPrunableWorktree && renderPrunableIndicator()}
 
         {renderRepoIndicators({
           aheadBehind: this.props.aheadBehind,
@@ -159,6 +186,7 @@ export class RepositoryListItem extends React.Component<
     const gitHubRepo = repo instanceof Repository ? repo.gitHubRepository : null
     const alias = repo instanceof Repository ? repo.alias : null
     const realName = gitHubRepo ? gitHubRepo.fullName : repo.name
+    const path = this.props.worktree?.path ?? repo.path
 
     return (
       <>
@@ -166,8 +194,11 @@ export class RepositoryListItem extends React.Component<
           <strong>{realName}</strong>
           {alias && <> ({alias})</>}
         </div>
-        <div>{repo.path}</div>
+        <div>{path}</div>
         {this.props.branchName && <div>Branch: {this.props.branchName}</div>}
+        {this.props.isPrunableWorktree && (
+          <div>This worktree entry is stale and should be pruned.</div>
+        )}
       </>
     )
   }
@@ -177,6 +208,9 @@ export class RepositoryListItem extends React.Component<
       <>
         <div>{worktree.path}</div>
         {this.props.branchName && <div>Branch: {this.props.branchName}</div>}
+        {this.props.isPrunableWorktree && (
+          <div>This worktree entry is stale and should be pruned.</div>
+        )}
       </>
     )
   }
@@ -188,11 +222,16 @@ export class RepositoryListItem extends React.Component<
     ) {
       return (
         nextProps.repository.id !== this.props.repository.id ||
+        nextProps.title !== this.props.title ||
         nextProps.matches !== this.props.matches ||
         nextProps.branchName !== this.props.branchName ||
+        nextProps.worktreePathDisambiguation !==
+          this.props.worktreePathDisambiguation ||
         nextProps.needsDisambiguation !== this.props.needsDisambiguation ||
         nextProps.aheadBehind !== this.props.aheadBehind ||
         nextProps.changedFilesCount !== this.props.changedFilesCount ||
+        nextProps.isNestedWorktree !== this.props.isNestedWorktree ||
+        nextProps.isPrunableWorktree !== this.props.isPrunableWorktree ||
         nextProps.worktree !== this.props.worktree
       )
     } else {
@@ -247,6 +286,18 @@ const renderChangesIndicator = () => {
       disabled={enableAccessibleListToolTips()}
     >
       <Octicon symbol={octicons.dotFill} />
+    </TooltippedContent>
+  )
+}
+
+const renderPrunableIndicator = () => {
+  return (
+    <TooltippedContent
+      className="prunable-indicator-wrapper"
+      tooltip="This worktree entry is stale and should be pruned"
+      disabled={enableAccessibleListToolTips()}
+    >
+      <Octicon symbol={octicons.alert} />
     </TooltippedContent>
   )
 }

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -92,6 +92,16 @@
         vertical-align: text-bottom;
       }
     }
+
+    .worktree-path-disambiguation {
+      color: var(--text-secondary-color);
+      font-size: var(--font-size-sm);
+      margin-left: var(--spacing-half);
+      margin-right: var(--spacing-half);
+      @include ellipsis;
+      flex-shrink: 1;
+      min-width: 0;
+    }
   }
 
   .filter-list-group-header {
@@ -216,6 +226,19 @@
 
     .octicon {
       color: var(--tab-bar-active-color);
+      width: auto;
+    }
+  }
+
+  .prunable-indicator-wrapper {
+    display: flex;
+    min-width: 12px;
+    justify-content: center;
+    align-items: center;
+    margin-left: var(--spacing-half);
+
+    .octicon {
+      color: var(--toolbar-dropdown-text-warning-color);
       width: auto;
     }
   }

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../../src/lib/copilot/model'
 import { getConflictResolutionModelDisplay } from '../../src/lib/copilot/conflict-resolution-model'
 import { encodeModelKey, IBYOKProvider } from '../../src/lib/copilot/byok'
 

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -1,9 +1,21 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
+import {
+  buildPinnedGroup,
+  filterPinnedFromGroups,
+  groupRepositories,
+  isRepositoryListItemPinned,
+} from '../../src/ui/repositories-list/group-repositories'
+import {
+  getWorktreeFamilyRepositories,
+  shouldShowRepositoryListBranchName,
+} from '../../src/ui/repositories-list/repositories-list'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { CloningRepository } from '../../src/models/cloning-repository'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
+import { WorktreeEntry } from '../../src/models/worktree'
+import { match } from '../../src/lib/fuzzy-find'
+import { ShowBranchNameInRepoListSetting } from '../../src/models/show-branch-name-in-repo-list'
 
 describe('repository list grouping', () => {
   const repositories: Array<Repository | CloningRepository> = [
@@ -27,6 +39,33 @@ describe('repository list grouping', () => {
   ]
 
   const cache = new Map<number, ILocalRepositoryState>()
+
+  const buildWorktree = (
+    path: string,
+    type: WorktreeEntry['type'],
+    branch: string | null,
+    isPrunable: boolean = false
+  ): WorktreeEntry => ({
+    path,
+    type,
+    branch,
+    head: 'deadbeef',
+    isDetached: branch === null,
+    isLocked: false,
+    isPrunable,
+  })
+
+  const buildLocalState = (
+    worktrees: ReadonlyArray<WorktreeEntry>,
+    overrides: Partial<Omit<ILocalRepositoryState, 'worktrees'>> = {}
+  ): ILocalRepositoryState => ({
+    aheadBehind: null,
+    changedFilesCount: 0,
+    branchName: 'main',
+    defaultBranchName: 'main',
+    worktrees,
+    ...overrides,
+  })
 
   it('groups repositories by owners/Enterprise/Other', () => {
     const grouped = groupRepositories(repositories, cache, [])
@@ -152,5 +191,696 @@ describe('repository list grouping', () => {
 
     assert.equal(grouped[2].items[1].text[0], 'enterprise-repo')
     assert(grouped[2].items[1].needsDisambiguation)
+  })
+
+  it('deduplicates saved repositories from the same worktree family', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([linkedRepo, mainRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 2)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.repository.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.isNestedWorktree),
+      [false, true]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.sourceRepository?.path ?? null),
+      [null, mainPath]
+    )
+  })
+
+  it('keeps saved worktree repositories flat when sidebar worktree rows are disabled', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [linkedRepo, mainRepo],
+      worktreeCache,
+      [],
+      {
+        showWorktreesInRepoList: false,
+      }
+    )
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 2)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.repository.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree),
+      [null, null]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.isNestedWorktree),
+      [false, false]
+    )
+  })
+
+  it('uses linked worktree state to render a saved main worktree family', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const linkedAheadBehind = { ahead: 1, behind: 0 }
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [
+        linkedRepo.id,
+        buildLocalState(worktrees, {
+          aheadBehind: linkedAheadBehind,
+          changedFilesCount: 3,
+        }),
+      ],
+    ])
+
+    const grouped = groupRepositories([linkedRepo, mainRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 2)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.repository.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.isNestedWorktree),
+      [false, true]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.changedFilesCount),
+      [0, 3]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.aheadBehind),
+      [null, linkedAheadBehind]
+    )
+  })
+
+  it('does not show main repository status on linked worktree rows', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const mainAheadBehind = { ahead: 1, behind: 2 }
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [
+        mainRepo.id,
+        buildLocalState(worktrees, {
+          aheadBehind: mainAheadBehind,
+          changedFilesCount: 7,
+        }),
+      ],
+    ])
+
+    const grouped = groupRepositories([mainRepo, linkedRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 2)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.repository.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.changedFilesCount),
+      [7, 0]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.aheadBehind),
+      [mainAheadBehind, null]
+    )
+  })
+
+  it('matches linked worktree rows by their worktree path name', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(
+      linkedPath,
+      2,
+      null,
+      false,
+      'Feature A Worktree'
+    )
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([mainRepo, linkedRepo], worktreeCache, [])
+    const linkedItem = grouped[0].items[1]
+
+    assert.equal(linkedItem.title, 'Feature A Worktree')
+    assert(linkedItem.text.some(text => text.includes('main-repo-feature-a')))
+
+    const filteredByLinkedWorktree = match(
+      'feature-a',
+      grouped[0].items,
+      item => item.text
+    )
+    assert.deepEqual(
+      new Set(filteredByLinkedWorktree.map(item => item.item.title)),
+      new Set(['Feature A Worktree'])
+    )
+    const filteredByMainWorktree = match(
+      'main-repo',
+      grouped[0].items,
+      item => item.text
+    )
+    assert.deepEqual(
+      new Set(filteredByMainWorktree.map(item => item.item.title)),
+      new Set(['main-repo', 'Feature A Worktree'])
+    )
+    const linkedRowMatchedByMainWorktree = filteredByMainWorktree.find(
+      item => item.item.title === 'Feature A Worktree'
+    )
+    assert(linkedRowMatchedByMainWorktree !== undefined)
+    assert.deepEqual(linkedRowMatchedByMainWorktree.matches.title, [])
+    assert(linkedRowMatchedByMainWorktree.matches.subtitle.length > 0)
+  })
+
+  it('keeps same-name worktrees distinguishable by branch and path', () => {
+    const mainPath = '/tmp/repo'
+    const linkedPath = '/tmp/worktree-path/repo'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/same-name'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([mainRepo, linkedRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.title),
+      ['repo', 'repo']
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.branchName),
+      ['main', 'feature/same-name']
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.needsBranchNameDisambiguation),
+      [true, true]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktreePathDisambiguation),
+      ['/tmp', '/tmp/worktree-path']
+    )
+    assert.equal(
+      shouldShowRepositoryListBranchName(
+        grouped[0].items[0],
+        ShowBranchNameInRepoListSetting.Never
+      ),
+      true
+    )
+    assert.equal(
+      shouldShowRepositoryListBranchName(
+        grouped[0].items[1],
+        ShowBranchNameInRepoListSetting.Never
+      ),
+      true
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [mainPath, linkedPath]
+    )
+
+    const filteredByPathParent = match(
+      'worktree-path',
+      grouped[0].items,
+      item => item.text
+    )
+    assert.deepEqual(
+      new Set(filteredByPathParent.map(item => item.item.worktree?.path)),
+      new Set([linkedPath])
+    )
+  })
+
+  it('does not match linked worktrees through generic worktree parent directories', () => {
+    const mainPath = '/tmp/repos/root-repo'
+    const otherPath = '/tmp/repos/.worktrees/root-feature-a'
+    const targetPath = '/tmp/repos/.worktrees/root-kts-target'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const otherRepo = new Repository(otherPath, 2, null, false)
+    const targetRepo = new Repository(targetPath, 3, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(otherPath, 'linked', 'refs/heads/feature/feature-a'),
+      buildWorktree(targetPath, 'linked', 'refs/heads/feature/kts-target'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [otherRepo.id, buildLocalState(worktrees)],
+      [targetRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [mainRepo, otherRepo, targetRepo],
+      worktreeCache,
+      []
+    )
+    const filteredByKts = match('kts', grouped[0].items, item => item.text)
+
+    assert.deepEqual(
+      filteredByKts.map(item => item.item.worktree?.path),
+      [targetPath]
+    )
+  })
+
+  it('keeps detached same-name worktrees visibly distinguishable by path', () => {
+    const mainPath = '/tmp/main-parent/repo'
+    const linkedPath = '/tmp/linked-parent/repo'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', null),
+      buildWorktree(linkedPath, 'linked', null),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([mainRepo, linkedRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.title),
+      ['repo', 'repo']
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.branchName),
+      [null, null]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktreePathDisambiguation),
+      ['/tmp/main-parent', '/tmp/linked-parent']
+    )
+    assert.equal(
+      shouldShowRepositoryListBranchName(
+        grouped[0].items[0],
+        ShowBranchNameInRepoListSetting.Never
+      ),
+      false
+    )
+    assert.equal(
+      shouldShowRepositoryListBranchName(
+        grouped[0].items[1],
+        ShowBranchNameInRepoListSetting.Never
+      ),
+      false
+    )
+  })
+
+  it('merges worktree family state when the first saved linked worktree has a stale cache', () => {
+    const mainPath = '/tmp/main-repo'
+    const featureBPath = '/tmp/main-repo-feature-b'
+    const featureAPath = '/tmp/main-repo-feature-a'
+    const featureBRepo = new Repository(featureBPath, 2, null, false)
+    const featureARepo = new Repository(featureAPath, 3, null, false)
+    const partialWorktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(featureBPath, 'linked', 'refs/heads/feature/feature-b'),
+    ]
+    const completeWorktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(featureBPath, 'linked', 'refs/heads/feature/feature-b'),
+      buildWorktree(featureAPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [featureBRepo.id, buildLocalState(partialWorktrees)],
+      [featureARepo.id, buildLocalState(completeWorktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [featureBRepo, featureARepo],
+      worktreeCache,
+      []
+    )
+
+    assert.equal(grouped.length, 1)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [mainPath, featureAPath, featureBPath]
+    )
+  })
+
+  it('shows the root worktree and nests linked worktrees when the main worktree is not saved', () => {
+    const mainPath = '/tmp/main-repo'
+    const featureBPath = '/tmp/main-repo-feature-b'
+    const featureAPath = '/tmp/main-repo-feature-a'
+    const featureBRepo = new Repository(featureBPath, 2, null, false)
+    const featureARepo = new Repository(featureAPath, 3, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(featureAPath, 'linked', 'refs/heads/feature/feature-a'),
+      buildWorktree(featureBPath, 'linked', 'refs/heads/feature/feature-b'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [featureBRepo.id, buildLocalState(worktrees)],
+      [featureARepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [featureARepo, featureBRepo],
+      worktreeCache,
+      []
+    )
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 3)
+    assert.deepEqual(
+      grouped[0].items.map(item => item.title),
+      ['main-repo', 'main-repo-feature-a', 'main-repo-feature-b']
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [mainPath, featureAPath, featureBPath]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.isNestedWorktree),
+      [false, true, true]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.isSyntheticWorktreeRoot),
+      [true, false, false]
+    )
+    assert.deepEqual(
+      grouped[0].items.map(item => item.familyMainPath),
+      [mainPath, mainPath, mainPath]
+    )
+    assert.equal(grouped[0].items[0].sourceRepository?.path, featureAPath)
+    assert.equal(
+      isRepositoryListItemPinned(
+        grouped[0].items[0],
+        [featureBRepo.id],
+        [featureARepo, featureBRepo],
+        worktreeCache
+      ),
+      true
+    )
+  })
+
+  it('keeps pinned worktree families together when only one saved repository id is pinned', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([mainRepo, linkedRepo], worktreeCache, [])
+    const pinsGroup = buildPinnedGroup([mainRepo.id], grouped)
+    const filteredGroups = filterPinnedFromGroups([mainRepo.id], grouped)
+
+    assert.notEqual(pinsGroup, null)
+    assert.deepEqual(
+      pinsGroup?.items.map(item => item.worktree?.path),
+      [mainPath, linkedPath]
+    )
+    assert.equal(filteredGroups.length, 0)
+  })
+
+  it('preserves persisted pin order when expanding worktree families', () => {
+    const featureAMainPath = '/tmp/feature-a'
+    const featureALinkedPath = '/tmp/feature-a-feature'
+    const featureBMainPath = '/tmp/feature-b'
+    const featureBLinkedPath = '/tmp/feature-b-feature'
+    const featureAMainRepo = new Repository(featureAMainPath, 1, null, false)
+    const featureALinkedRepo = new Repository(
+      featureALinkedPath,
+      2,
+      null,
+      false
+    )
+    const featureBMainRepo = new Repository(featureBMainPath, 3, null, false)
+    const featureBLinkedRepo = new Repository(
+      featureBLinkedPath,
+      4,
+      null,
+      false
+    )
+    const featureAWorktrees = [
+      buildWorktree(featureAMainPath, 'main', 'refs/heads/main'),
+      buildWorktree(
+        featureALinkedPath,
+        'linked',
+        'refs/heads/feature/feature-a'
+      ),
+    ]
+    const featureBWorktrees = [
+      buildWorktree(featureBMainPath, 'main', 'refs/heads/main'),
+      buildWorktree(
+        featureBLinkedPath,
+        'linked',
+        'refs/heads/feature/feature-b'
+      ),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [featureAMainRepo.id, buildLocalState(featureAWorktrees)],
+      [featureALinkedRepo.id, buildLocalState(featureAWorktrees)],
+      [featureBMainRepo.id, buildLocalState(featureBWorktrees)],
+      [featureBLinkedRepo.id, buildLocalState(featureBWorktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [
+        featureAMainRepo,
+        featureALinkedRepo,
+        featureBMainRepo,
+        featureBLinkedRepo,
+      ],
+      worktreeCache,
+      []
+    )
+    const pinsGroup = buildPinnedGroup(
+      [featureBMainRepo.id, featureAMainRepo.id],
+      grouped
+    )
+
+    assert.deepEqual(
+      pinsGroup?.items.map(item => item.worktree?.path),
+      [
+        featureBMainPath,
+        featureBLinkedPath,
+        featureAMainPath,
+        featureALinkedPath,
+      ]
+    )
+  })
+
+  it('marks prunable worktrees in the sidebar item model', () => {
+    const mainPath = '/tmp/main-repo'
+    const stalePath = '/tmp/main-repo-stale'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(stalePath, 'linked', 'refs/heads/feature/stale', true),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories([mainRepo], worktreeCache, [])
+
+    assert.equal(grouped.length, 1)
+    assert.equal(grouped[0].items.length, 2)
+    assert.equal(grouped[0].items[1].worktree?.path, stalePath)
+    assert.equal(grouped[0].items[1].isPrunableWorktree, true)
+    assert.equal(grouped[0].items[1].sourceRepository?.path, mainPath)
+  })
+
+  it('finds every saved worktree family repository for stale-prune refresh', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const stalePath = '/tmp/main-repo-stale'
+    const unrelatedPath = '/tmp/unrelated-repo'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const unrelatedRepo = new Repository(unrelatedPath, 3, null, false)
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+      buildWorktree(stalePath, 'linked', 'refs/heads/feature/stale', true),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+      [
+        unrelatedRepo.id,
+        buildLocalState([
+          buildWorktree(unrelatedPath, 'main', 'refs/heads/main'),
+        ]),
+      ],
+    ])
+
+    assert.deepEqual(
+      getWorktreeFamilyRepositories(
+        mainRepo,
+        [mainRepo, linkedRepo, unrelatedRepo],
+        worktreeCache
+      ).map(repository => repository.path),
+      [mainPath, linkedPath]
+    )
+    assert.deepEqual(
+      getWorktreeFamilyRepositories(
+        linkedRepo,
+        [mainRepo, linkedRepo, unrelatedRepo],
+        worktreeCache
+      ).map(repository => repository.path),
+      [mainPath, linkedPath]
+    )
+  })
+
+  it('shows only the selected linked worktree in Recent', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const fillerRepos = Array.from(
+      { length: 6 },
+      (_, i) => new Repository(`/tmp/filler-${i}`, i + 10, null, false)
+    )
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+      [linkedRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [mainRepo, linkedRepo, ...fillerRepos],
+      worktreeCache,
+      [{ repositoryId: linkedRepo.id, path: linkedPath }]
+    )
+
+    assert.equal(grouped[0].identifier.kind, 'recent')
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [linkedPath]
+    )
+  })
+
+  it('shows the selected linked worktree in Recent when only the main worktree state is loaded', () => {
+    const mainPath = '/tmp/main-repo'
+    const linkedPath = '/tmp/main-repo-feature-a'
+    const mainRepo = new Repository(mainPath, 1, null, false)
+    const linkedRepo = new Repository(linkedPath, 2, null, false)
+    const fillerRepos = Array.from(
+      { length: 6 },
+      (_, i) => new Repository(`/tmp/filler-${i}`, i + 10, null, false)
+    )
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(linkedPath, 'linked', 'refs/heads/feature/feature-a'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [mainRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [mainRepo, linkedRepo, ...fillerRepos],
+      worktreeCache,
+      [{ repositoryId: linkedRepo.id, path: linkedPath }]
+    )
+
+    assert.equal(grouped[0].identifier.kind, 'recent')
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [linkedPath]
+    )
+  })
+
+  it('shows recent worktree paths separately when they share a repository id', () => {
+    const mainPath = '/tmp/main-repo'
+    const featureAPath = '/tmp/main-repo-feature-a'
+    const featureBPath = '/tmp/main-repo-feature-b'
+    const currentRepo = new Repository(featureBPath, 1, null, false)
+    const fillerRepos = Array.from(
+      { length: 7 },
+      (_, i) => new Repository(`/tmp/filler-${i}`, i + 10, null, false)
+    )
+    const worktrees = [
+      buildWorktree(mainPath, 'main', 'refs/heads/main'),
+      buildWorktree(featureAPath, 'linked', 'refs/heads/feature/feature-a'),
+      buildWorktree(featureBPath, 'linked', 'refs/heads/feature/feature-b'),
+    ]
+    const worktreeCache = new Map<number, ILocalRepositoryState>([
+      [currentRepo.id, buildLocalState(worktrees)],
+    ])
+
+    const grouped = groupRepositories(
+      [currentRepo, ...fillerRepos],
+      worktreeCache,
+      [
+        { repositoryId: currentRepo.id, path: featureAPath },
+        { repositoryId: currentRepo.id, path: featureBPath },
+      ]
+    )
+
+    assert.equal(grouped[0].identifier.kind, 'recent')
+    assert.deepEqual(
+      grouped[0].items.map(item => item.worktree?.path),
+      [featureAPath, featureBPath]
+    )
   })
 })

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -48,6 +48,48 @@ describe('RepositoriesStore', () => {
     })
   })
 
+  describe('removing a repository by path', () => {
+    it('removes and returns the saved repository at the path', async () => {
+      const firstRepository = await repositoriesStore.addRepository(
+        '/some/cool/path',
+        '/some/cool/path/.git',
+        null
+      )
+      await repositoriesStore.addRepository(
+        '/some/other/path',
+        '/some/other/path/.git',
+        null
+      )
+
+      const removedRepository = await repositoriesStore.removeRepositoryForPath(
+        firstRepository.path
+      )
+      const repositories = await repositoriesStore.getAll()
+
+      assert.equal(removedRepository?.id, firstRepository.id)
+      assert.deepEqual(
+        repositories.map(repository => repository.path),
+        ['/some/other/path']
+      )
+    })
+
+    it('returns null when no repository is saved at the path', async () => {
+      await repositoriesStore.addRepository(
+        '/some/cool/path',
+        '/some/cool/path/.git',
+        null
+      )
+
+      const removedRepository = await repositoriesStore.removeRepositoryForPath(
+        '/missing/path'
+      )
+      const repositories = await repositoriesStore.getAll()
+
+      assert.equal(removedRepository, null)
+      assert.equal(repositories.length, 1)
+    })
+  })
+
   describe('updating a GitHub repository', () => {
     const apiRepo: IAPIFullRepository = {
       clone_url: 'https://github.com/my-user/my-repo',

--- a/app/test/unit/repository-list-item-context-menu-test.ts
+++ b/app/test/unit/repository-list-item-context-menu-test.ts
@@ -1,0 +1,198 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import { Repository } from '../../src/models/repository'
+import { WorktreeEntry } from '../../src/models/worktree'
+import {
+  generateRepositoryListContextMenu,
+  generateSyntheticWorktreeRootContextMenu,
+  generateWorktreeListItemContextMenu,
+} from '../../src/ui/repositories-list/repository-list-item-context-menu'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
+import { captureClipboardWrites } from '../helpers/ui/electron'
+
+describe('repository list item context menu', () => {
+  it('copies the repository name when a normal repository row has a worktree path', () => {
+    const repository = new Repository(
+      '/tmp/desktop-custom',
+      1,
+      gitHubRepoFixture({ owner: 'example', name: 'desktop' }),
+      false
+    )
+    const clipboard = captureClipboardWrites()
+    try {
+      const items = generateRepositoryListContextMenu({
+        repository,
+        worktreePath: repository.path,
+        shellLabel: undefined,
+        externalEditorLabel: undefined,
+        askForConfirmationOnRemoveRepository: false,
+        onViewOnGitHub: () => {},
+        onOpenInShell: () => {},
+        onShowRepository: () => {},
+        onOpenInExternalEditor: () => {},
+        onRemoveRepository: () => {},
+        onChangeRepositoryAlias: () => {},
+        onRemoveRepositoryAlias: () => {},
+        onChangeRepositoryGroupName: () => {},
+        onRemoveRepositoryGroupName: () => {},
+        onCopyRepoPath: () => {},
+      })
+
+      items
+        .find(item => item.label?.toLowerCase().includes('copy repo name'))
+        ?.action?.()
+
+      assert.deepEqual(clipboard.writes, ['desktop'])
+    } finally {
+      clipboard.restore()
+    }
+  })
+
+  it('copies the row worktree path when a repository row represents another worktree', () => {
+    const repository = new Repository(
+      '/tmp/repo-feature',
+      1,
+      gitHubRepoFixture({ owner: 'example', name: 'repo' }),
+      false
+    )
+    let copiedPath: string | null = null
+    const items = generateRepositoryListContextMenu({
+      repository,
+      worktreePath: '/tmp/repo',
+      shellLabel: undefined,
+      externalEditorLabel: undefined,
+      askForConfirmationOnRemoveRepository: false,
+      onViewOnGitHub: () => {},
+      onOpenInShell: () => {},
+      onShowRepository: () => {},
+      onOpenInExternalEditor: () => {},
+      onRemoveRepository: () => {},
+      onChangeRepositoryAlias: () => {},
+      onRemoveRepositoryAlias: () => {},
+      onChangeRepositoryGroupName: () => {},
+      onRemoveRepositoryGroupName: () => {},
+      onCopyRepoPath: path => {
+        copiedPath = path
+      },
+    })
+
+    items
+      .find(item => item.label?.toLowerCase().includes('copy repo path'))
+      ?.action?.()
+
+    assert.equal(copiedPath, '/tmp/repo')
+  })
+
+  it('keeps synthetic root worktree menu actions non-mutating', () => {
+    const sourceRepository = new Repository(
+      '/tmp/repo-feature',
+      1,
+      gitHubRepoFixture({ owner: 'example', name: 'repo' }),
+      false
+    )
+    let copiedPath: string | null = null
+    let unpinnedRepository: Repository | null = null
+    const clipboard = captureClipboardWrites()
+    try {
+      const items = generateSyntheticWorktreeRootContextMenu({
+        name: 'repo',
+        path: '/tmp/repo',
+        sourceRepository,
+        isPinned: true,
+        onCopyRepoPath: path => {
+          copiedPath = path
+        },
+        onUnpinRepository: repository => {
+          unpinnedRepository = repository
+        },
+      })
+
+      const labels = items
+        .map(item => item.label?.toLowerCase())
+        .filter((label): label is string => label !== undefined)
+
+      assert(labels.includes('unpin repository'))
+      assert(labels.includes('copy repo name'))
+      assert(labels.includes('copy repo path'))
+      assert(!labels.some(label => label.includes('alias')))
+      assert(!labels.some(label => label.includes('group')))
+      assert(!labels.some(label => label.includes('remove')))
+      assert(!labels.some(label => label.includes('open')))
+
+      items
+        .find(item => item.label?.toLowerCase().includes('copy repo name'))
+        ?.action?.()
+      items
+        .find(item => item.label?.toLowerCase().includes('copy repo path'))
+        ?.action?.()
+      items
+        .find(item => item.label?.toLowerCase().includes('unpin repository'))
+        ?.action?.()
+
+      assert.deepEqual(clipboard.writes, ['repo'])
+      assert.equal(copiedPath, '/tmp/repo')
+      assert.equal(unpinnedRepository, sourceRepository)
+    } finally {
+      clipboard.restore()
+    }
+  })
+
+  it('disables stale worktree path actions while keeping prune available', () => {
+    const repository = new Repository(
+      '/tmp/repo',
+      1,
+      gitHubRepoFixture({ owner: 'example', name: 'repo' }),
+      false
+    )
+    const worktree: WorktreeEntry = {
+      path: '/tmp/repo-stale',
+      type: 'linked',
+      branch: 'refs/heads/feature/stale',
+      head: 'deadbeef',
+      isDetached: false,
+      isLocked: false,
+      isPrunable: true,
+    }
+
+    const items = generateWorktreeListItemContextMenu({
+      repository,
+      worktree,
+      shellLabel: undefined,
+      externalEditorLabel: undefined,
+      onCreateWorktree: () => {},
+      onRenameWorktree: () => {},
+      onDeleteWorktree: () => {},
+      onPruneStaleWorktrees: () => {},
+      onViewOnGitHub: () => {},
+      onOpenWorktreeInNewWindow: () => {},
+      onOpenInShell: () => {},
+      onShowRepository: () => {},
+      onOpenInExternalEditor: () => {},
+      onCopyWorktreePath: () => {},
+    })
+
+    const findItem = (label: string) =>
+      items.find(item => item.label?.toLowerCase().includes(label))
+
+    assert.equal(findItem('new worktree')?.enabled, false)
+    assert.equal(findItem('rename worktree')?.enabled, false)
+    assert.equal(findItem('open worktree in new window')?.enabled, false)
+    assert.equal(findItem('open in shell')?.enabled, false)
+    assert.equal(
+      items.find(item =>
+        [
+          'reveal in finder',
+          'show in explorer',
+          'show in your file manager',
+        ].includes(item.label?.toLowerCase() ?? '')
+      )?.enabled,
+      false
+    )
+    assert.equal(findItem('open in external editor')?.enabled, false)
+    assert.equal(findItem('delete worktree')?.enabled, false)
+
+    assert.notEqual(findItem('copy worktree path'), undefined)
+    assert.notEqual(findItem('prune stale worktrees'), undefined)
+  })
+})

--- a/app/test/unit/stores/copilot-store-test.ts
+++ b/app/test/unit/stores/copilot-store-test.ts
@@ -1,5 +1,5 @@
 import type { CopilotClient, CopilotSession } from '@github/copilot-sdk'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../../../src/lib/copilot/model'
 import assert from 'node:assert'
 import { after, before, describe, it } from 'node:test'
 import { getDotComAPIEndpoint } from '../../../src/lib/api'

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -24,7 +24,7 @@ import {
   type IBYOKProvider,
 } from '../../../src/lib/copilot/byok'
 import { Account } from '../../../src/models/account'
-import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
+import type { CopilotModel as Model } from '../../../src/lib/copilot/model'
 import { setNumberFormatPreference } from '../../../src/models/formatting-preferences'
 
 interface IAccountOptions {

--- a/app/test/unit/ui/repositories-list-test.ts
+++ b/app/test/unit/ui/repositories-list-test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  Repository,
+  ILocalRepositoryState,
+} from '../../../src/models/repository'
+import { WorktreeEntry } from '../../../src/models/worktree'
+import { groupRepositories } from '../../../src/ui/repositories-list/group-repositories'
+import { RepositoriesList } from '../../../src/ui/repositories-list/repositories-list'
+
+const buildWorktree = (
+  path: string,
+  type: WorktreeEntry['type'],
+  branch: string | null
+): WorktreeEntry => ({
+  path,
+  type,
+  branch,
+  head: 'deadbeef',
+  isDetached: branch === null,
+  isLocked: false,
+  isPrunable: false,
+})
+
+const buildLocalState = (
+  worktrees: ReadonlyArray<WorktreeEntry>
+): ILocalRepositoryState => ({
+  aheadBehind: null,
+  changedFilesCount: 0,
+  branchName: 'feature',
+  defaultBranchName: 'main',
+  worktrees,
+})
+
+describe('RepositoriesList', () => {
+  it('switches a synthetic root worktree row back to the root path', () => {
+    const mainPath = '/tmp/project-alpha'
+    const linkedPath = '/tmp/project-alpha-feature-a'
+    const repository = new Repository(linkedPath, 1, null, false)
+    const mainWorktree = buildWorktree(mainPath, 'main', 'refs/heads/main')
+    const linkedWorktree = buildWorktree(
+      linkedPath,
+      'linked',
+      'refs/heads/feature/feature-a'
+    )
+    const worktreeState = new Map<number, ILocalRepositoryState>([
+      [repository.id, buildLocalState([mainWorktree, linkedWorktree])],
+    ])
+    const groups = groupRepositories([repository], worktreeState, [])
+    const rootItem = groups[0].items[0]
+
+    assert.equal(rootItem.isSyntheticWorktreeRoot, true)
+    assert.equal(rootItem.worktree?.path, mainPath)
+
+    let selectedRepository: Repository | null = null
+    let switchedRepository: Repository | null = null
+    let switchedWorktree: WorktreeEntry | null = null
+    const dispatcher = {
+      recordRepoClicked() {},
+      closeFoldout() {},
+      switchWorktree(repo: Repository, worktree: WorktreeEntry) {
+        switchedRepository = repo
+        switchedWorktree = worktree
+      },
+      postError(error: Error) {
+        throw error
+      },
+    }
+
+    const list = new RepositoriesList({
+      dispatcher,
+      onSelectionChanged: (repo: Repository) => {
+        selectedRepository = repo
+      },
+    } as any)
+
+    ;(list as any).onItemClick(rootItem)
+
+    assert.equal(selectedRepository, null)
+    assert.equal(switchedRepository, repository)
+    assert.equal(switchedWorktree, mainWorktree)
+  })
+})

--- a/app/test/unit/ui/repository-list-item-test.tsx
+++ b/app/test/unit/ui/repository-list-item-test.tsx
@@ -8,6 +8,7 @@ import { Owner } from '../../../src/models/owner'
 import { RepositoryListItem } from '../../../src/ui/repositories-list/repository-list-item'
 import { render, fireEvent, screen, waitFor } from '../../helpers/ui/render'
 import { IMatches } from '../../../src/lib/fuzzy-find'
+import { WorktreeEntry } from '../../../src/models/worktree'
 import {
   advanceTimersBy,
   enableTestTimers,
@@ -50,11 +51,15 @@ describe('RepositoryListItem', () => {
     const view = render(
       <RepositoryListItem
         repository={repository}
+        title="desktop"
         needsDisambiguation={false}
         matches={noMatches}
         aheadBehind={{ ahead: 2, behind: 1 }}
         changedFilesCount={3}
         branchName={'main'}
+        worktreePathDisambiguation={null}
+        isNestedWorktree={false}
+        isPrunableWorktree={false}
         worktree={null}
       />
     )
@@ -76,11 +81,15 @@ describe('RepositoryListItem', () => {
     const view = render(
       <RepositoryListItem
         repository={repository}
+        title="desktop-app"
         needsDisambiguation={true}
         matches={noMatches}
         aheadBehind={null}
         changedFilesCount={0}
         branchName={'main'}
+        worktreePathDisambiguation={null}
+        isNestedWorktree={false}
+        isPrunableWorktree={false}
         worktree={null}
       />
     )
@@ -97,11 +106,15 @@ describe('RepositoryListItem', () => {
     const view = render(
       <RepositoryListItem
         repository={repository}
+        title="desktop-app"
         needsDisambiguation={true}
         matches={noMatches}
         aheadBehind={null}
         changedFilesCount={0}
         branchName={'main'}
+        worktreePathDisambiguation={null}
+        isNestedWorktree={false}
+        isPrunableWorktree={false}
         worktree={null}
       />
     )
@@ -122,5 +135,41 @@ describe('RepositoryListItem', () => {
       assert.ok(screen.getByText('octocat/desktop', { selector: 'strong' }))
       assert.ok(screen.getByText(fixtureRepositoryPath))
     })
+  })
+
+  it('renders visible path disambiguation for duplicate-name worktree rows', () => {
+    const repository = createRepository()
+    const worktree: WorktreeEntry = {
+      path: '/tmp/worktree-path/repo',
+      type: 'linked',
+      branch: null,
+      head: 'deadbeef',
+      isDetached: true,
+      isLocked: false,
+      isPrunable: false,
+    }
+    const view = render(
+      <RepositoryListItem
+        repository={repository}
+        title="repo"
+        needsDisambiguation={false}
+        matches={noMatches}
+        aheadBehind={null}
+        changedFilesCount={0}
+        branchName={null}
+        worktreePathDisambiguation="/tmp/worktree-path"
+        isNestedWorktree={true}
+        isPrunableWorktree={false}
+        worktree={worktree}
+      />
+    )
+
+    const name = view.container.querySelector('.name')
+    const pathDisambiguation = view.container.querySelector(
+      '.worktree-path-disambiguation'
+    )
+
+    assert.equal(name?.textContent, 'repo')
+    assert.equal(pathDisambiguation?.textContent, '/tmp/worktree-path')
   })
 })

--- a/app/test/unit/ui/section-filter-list-test.tsx
+++ b/app/test/unit/ui/section-filter-list-test.tsx
@@ -1,0 +1,32 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { getFilteredItems } from '../../../src/ui/lib/section-filter-list'
+
+interface ITestItem {
+  readonly id: string
+  readonly text: ReadonlyArray<string>
+}
+
+describe('SectionFilterList', () => {
+  it('can preserve item order when filtering', () => {
+    const items: ReadonlyArray<ITestItem> = [
+      {
+        id: 'root',
+        text: ['project-alpha', 'project-alpha project-alpha-feature-a'],
+      },
+      {
+        id: 'linked',
+        text: [
+          'project-alpha-feature-a',
+          'project-alpha project-alpha-feature-a',
+        ],
+      },
+    ]
+    const rows = getFilteredItems('feature-a', items, true).map(
+      row => row.item.id
+    )
+
+    assert.deepEqual(rows, ['root', 'linked'])
+  })
+})


### PR DESCRIPTION
Closes #192

## Problem

v3.5.13 switched GitHub Desktop Plus to the upstream worktree implementation, but the repository sidebar lost several behaviors that existed in the previous GitHub Desktop Plus worktree implementation:

- saved main and linked worktree paths can render as duplicate flat repository rows instead of one worktree family
- filtering no longer reliably matches linked worktree display names / path basenames while keeping the root row above the matching linked rows
- saved linked worktree rows can cause the same family to be emitted again rather than folding into the Git-discovered family
- explicitly selecting the parent/root row should switch the current worktree back to the main worktree path
- recent repository rows should represent the actual recent worktree selection, not expand an entire worktree family

## Solution

This keeps the upstream worktree data model and restores the sidebar behavior as a display-layer projection. The grouping code derives worktree families from saved repositories and loaded Git worktree state, keyed by the normalized main worktree path, then renders those families as a root row plus nested linked worktree rows.

This PR is rebased on top of the upstream fixes for worktree-name search, hierarchy-preserving filtered results, and Enter selection. The hierarchy post-processing now groups by worktree family path instead of only repository id, so those upstream behaviors still work when a saved linked worktree row is backed by a different repository id than the root row.

Changes:

- group saved main and linked worktree repositories into one sidebar family when worktree rows are enabled
- deduplicate saved linked worktree entries against Git-discovered family rows
- keep linked worktree rows selectable, searchable, pinnable, context-menuable, and visually distinguishable by branch/path when names collide
- make synthetic root rows explicitly switch to the main worktree path
- keep stale/prunable worktree rows actionable and refresh all saved repositories in a worktree family
- track recent selections by repository id plus selected worktree path, expose a configurable recent count, and show only the selected recent worktree row in Recent
- preserve filtered repository-list order so parent rows stay above matching linked rows, including saved linked worktree rows with distinct repository ids
- hide inner virtualized section overflow so large account/org groups do not create nested scrollbars
- add local Copilot SDK model typings and client construction updates required for this branch to compile against the current SDK package

The intent is not to reintroduce the old persisted data model. The new behavior is derived from existing saved repository entries plus upstream worktree state.

## Acceptance Criteria

- [x] **Given** a saved root repository with linked worktrees, **When** the repository sidebar opens, **Then** the root row appears once and linked worktrees appear as nested rows.
- [x] **Given** both the root path and a linked worktree path are saved as repositories, **When** worktree rows are enabled, **Then** the sidebar emits one worktree family instead of duplicate families.
- [x] **Given** a linked worktree basename or branch matches the filter, **When** filtering the repository sidebar, **Then** the matching linked row remains visible under its root row.
- [x] **Given** the current worktree is linked, **When** the user selects the synthetic root row, **Then** the app switches to the main/root worktree path.
- [x] **Given** recent entries include linked worktree selections, **When** Recent is shown, **Then** it displays the actual selected worktree rows up to the configured limit.

## Risk Assessment

**Risk tier**: Medium

**Affected areas**: repository sidebar grouping/filtering, repository selection, worktree context menu actions, recent repository persistence, preferences UI, worktree refresh/prune flow, Copilot SDK compile compatibility.

**Coverage added for the main risks**:

- row grouping and deduplication: worktree families, linked-only saved paths, same-name worktrees, stale/prunable rows, pinned families, and Recent worktree paths
- filtering and hierarchy: linked worktree path/branch search, preserved parent-before-child order, and saved linked rows whose repository id differs from the root row
- selection dispatch: synthetic root rows switch to the root path; saved linked rows switch through their source/root repository
- context menu targeting: normal repository rows, linked worktree rows, synthetic root rows, and stale/prunable worktree rows
- persistence/config migration: path-aware Recent entries and configurable Recent count
- compile compatibility: Copilot SDK client/model type updates covered by `yarn compile:dev`

**Remaining risk**: manual UI density/regression risk in very large sidebar profiles, because the app does not have an end-to-end repository-sidebar fixture that mirrors a real multi-account worktree setup. I validated that manually with a local profile.

## Test Plan

**Automated**:

- `yarn test:unit app/test/unit/section-list-test.ts app/test/unit/ui/section-filter-list-test.tsx app/test/unit/repositories-list-grouping-test.ts app/test/unit/ui/repositories-list-test.ts app/test/unit/ui/repository-list-item-test.tsx app/test/unit/repository-list-item-context-menu-test.ts`
- `yarn compile:dev`
- `yarn build:prod`

**Manual QA**:

- Built an unpacked Linux app and verified the sidebar against a local profile with multiple root repositories and linked worktrees.
- Verified filtering by linked worktree names, nested family rendering, Recent worktree rows, root-row selection, and removal of nested account/org scrollbars.

## Screenshots

Omitted for now because the validating profile contains private repository and worktree names. The automated tests use neutral paths/branches for the row-shape and filtering cases. I can add synthetic screenshots if needed.

## Release notes

Notes: [Fixed] Restores grouped worktree rows and worktree-name filtering in the repository sidebar
