### PR TITLE
Set explicit window icon on Windows for app switcher

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -86,6 +86,11 @@ export class AppWindow {
       windowOptions.titleBarStyle = 'hidden'
     } else if (__WIN32__) {
       windowOptions.frame = false
+      // Windows resolves the app switcher (Alt+Tab/Win+Tab) icon from the
+      // window when it can't be resolved from the executable or the app user
+      // model id, such as in dev builds or when running a packaged build that
+      // hasn't been installed (i.e. hasn't had a shortcut created for it).
+      windowOptions.icon = path.join(__dirname, 'static', 'icon-logo.ico')
     } else if (__LINUX__) {
       const config = readMainProcessConfig()
       if (config.titleBarStyle === 'custom') {

--- a/app/src/main-process/crash-window.ts
+++ b/app/src/main-process/crash-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import { Emitter, Disposable } from 'event-kit'
+import * as path from 'path'
 import { ICrashDetails, ErrorType } from '../crash/shared'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
 import * as ipcMain from './ipc-main'
@@ -49,6 +50,8 @@ export class CrashWindow {
       windowOptions.titleBarStyle = 'hidden'
     } else if (__WIN32__) {
       windowOptions.frame = false
+      // See the matching option in app-window.ts for why this is needed.
+      windowOptions.icon = path.join(__dirname, 'static', 'icon-logo.ico')
     }
 
     this.window = new BrowserWindow(windowOptions)

--- a/script/build.ts
+++ b/script/build.ts
@@ -284,6 +284,17 @@ function copyStaticResources() {
     force: false,
     verbatimSymlinks: true,
   })
+
+  if (process.platform === 'win32') {
+    // The main window sets this as its icon so that the app switcher
+    // (Alt+Tab/Win+Tab) shows the right icon even when the icon can't be
+    // resolved from the executable or the app user model id, such as in dev
+    // builds or when running a packaged build that hasn't been installed.
+    cpSync(
+      join(getIconDirectory(), 'icon-logo.ico'),
+      join(destination, 'icon-logo.ico')
+    )
+  }
 }
 
 function moveAnalysisFiles() {


### PR DESCRIPTION
<!-- No existing issue covers this; #204 looks similar but is about Linux/KDE. -->
Closes — no existing issue; happy to open one if preferred.

## Description

On Windows, the main and crash windows are created without an explicit icon (`app-window.ts` only sets `windowOptions.icon` for Linux). The switcher icon therefore depends entirely on Windows resolving one externally:

- from the executable's embedded icon, which doesn't exist for dev builds (the binary is `electron.exe`), or
- from the App User Model ID, which dev builds hardcode to `com.squirrel.DesktopPlus.DesktopPlus` — an AUMID that only resolves if an installed Squirrel shortcut with that ID exists.

When neither resolves (dev builds, or a packaged build that runs without having been installed), Alt+Tab and Win+Tab show a blank icon.

This PR makes the icon explicit, mirroring what is already done on Linux:

- `script/build.ts`: copy the release channel's `icon-logo.ico` (from `app/static/logos/dev|prod/`) into `out/static/` on win32.
- `app-window.ts` / `crash-window.ts`: set that `.ico` as the `BrowserWindow` icon on `__WIN32__`.

**Tradeoffs considered:** an alternative would be dropping the hardcoded dev AUMID, but that would break notifications in dev builds; setting the window icon fixes the switcher without touching notification behavior. 

> Note for testing: Windows caches shell icons, so after installing a build with this fix a stale blank icon may persist until the icon cache refreshes.

### Screenshots

| Before | After |
| --- | --- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/eb212cbd-bf55-4e84-91e6-c4f1d3e938af" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/959e5821-3008-4547-96cb-f3dce9638ea1" /> |

## Release notes

Notes: [Fixed] Application icon is now shown in the Windows app switcher (Alt+Tab / Win+Tab) - #210