### PR TITLE
Fix: context menu 'Checkout Commit' incorrectly greyed out after previous checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ junit*.xml
 *.swp
 tslint-rules/
 playwright-videos/
-private/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ junit*.xml
 *.swp
 tslint-rules/
 playwright-videos/
+private/

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -869,7 +869,7 @@ export class CommitList extends React.Component<
     const isResettableCommit = !isHeadCommit
     const canBeResetTo =
       this.props.canResetToCommits === true && isResettableCommit
-    const canBeCheckedOut = actualRow > 0 //Cannot checkout the current commit
+    const canBeCheckedOut = !isHeadCommit //Cannot checkout the current commit
 
     const gitHubRepository = this.props.repository?.gitHubRepository
 


### PR DESCRIPTION
Closes [#2](https://github.com/jabelardo/desktop-plus/issues/2)

<!--
The canBeCheckedOut check in getContextMenuForSingleCommit() used 'actualRow > 0' which assumes the commit at index 0 in allHistoryCommitSHAs is always HEAD. After a 'Checkout Commit' operation (detached HEAD), allHistoryCommitSHAs may not be updated immediately — it still reflects the old branch state. A non-HEAD commit at index 0 caused actualRow > 0 to be false, incorrectly greying out the checkout option.

Fix: rely solely on !isHeadCommit. When headCommitSha is provided (set from currentTipSha), isHeadCommit is determined by SHA comparison (commit.sha === headCommitSha), which is always correct.
-->

